### PR TITLE
Searching in a text document now displays results as expected 

### DIFF
--- a/bookworm/document/formats/plain_text.py
+++ b/bookworm/document/formats/plain_text.py
@@ -35,6 +35,11 @@ class PlainTextDocument(SinglePageDocument):
         self.text = TextContentDecoder(content).get_utf8()
         super().read()
 
+    def __len__(self):
+        if self.text is None:
+            self.read()
+        return len(self.text)
+    
     def get_content(self):
         if len(self.text) > MAX_NUM_CHARS:
             return self.text

--- a/bookworm/gui/components.py
+++ b/bookworm/gui/components.py
@@ -8,6 +8,7 @@ import time
 from concurrent.futures import Future
 from functools import reduce
 from itertools import chain
+from typing import Optional
 
 import attr
 import wx
@@ -169,9 +170,11 @@ class PageRangeControl(sc.SizedPanel):
             to_page = self.toPage.GetValue() - 1
         return from_page, to_page
 
-    def get_text_range(self):
-        if not self.is_single_page_document:
-            raise TypeError("Text ranges are not supported in single page documents")
+    def get_text_range(self) -> Optional[TextRange]:
+        if self.is_single_page_document:
+            if self.doc.format == "txt":
+                return TextRange(0, len(self.doc))
+            return None                
         if selected_item := self.sectionChoice.GetSelection():
             section = self.sectionChoice.GetClientData(selected_item)
             start_pos, stop_pos = section.text_range

--- a/bookworm/utils/string.py
+++ b/bookworm/utils/string.py
@@ -56,6 +56,9 @@ class TextContentDecoder:
     def __repr__(self):
         return f"<{self.__class__.__name__}: content_length: {len(self.content)}, prefered_encoding: {self.prefered_encoding}>"
 
+    def __len__(self) -> int:
+        return len(self.content)
+    
     @classmethod
     def from_filename(
         cls,


### PR DESCRIPTION
## Link to issue number:
closes #168 
### Summary of the issue:
Whenever you attempt to search for some content in a text document results are not displayed.
### Description of how this pull request fixes the issue:
The issue was caused by the TextRange being feed incorrectly to the search request.
In plain text documents, and probably in single page documents in general, it is easy to assume that the text range we need to return is the  range that spans over the whole text.
Previously this was not accounted for, and  the attempt was to raise a TypeError
Now the proper text range will be returned if the document is a single page document and more precisely a text document, and nothing will be returned if otherwise.
### Testing performed:
Manual testing
### Known issues with pull request:
None 
@cary-rowen  and @DraganRatkovich can you confirm the issue is fixed on your end?