### PR TITLE
Document search with single page documents should now be more reliable

### DIFF
--- a/bookworm/document/formats/plain_text.py
+++ b/bookworm/document/formats/plain_text.py
@@ -29,7 +29,7 @@ class PlainTextDocument(SinglePageDocument):
     # Translators: the name of a document file format
     name = _("Plain Text File")
     extensions = ("*.txt",)
-    capabilities = DC.SINGLE_PAGE | DC.LINKS | DC.STRUCTURED_NAVIGATION
+    capabilities = (DC.SINGLE_PAGE | DC.LINKS | DC.STRUCTURED_NAVIGATION)
 
     def read(self):
         self.filename = self.get_file_system_path()

--- a/bookworm/gui/components.py
+++ b/bookworm/gui/components.py
@@ -18,6 +18,7 @@ from wx.lib.combotreebox import ComboTreeBox
 
 import bookworm.typehints as t
 from bookworm.concurrency import threaded_worker
+from bookworm.document import DocumentCapability as DC
 from bookworm.logger import logger
 from bookworm.structured_text import TextRange
 from bookworm.vendor.repeating_timer import RepeatingTimer
@@ -171,7 +172,7 @@ class PageRangeControl(sc.SizedPanel):
         return from_page, to_page
 
     def get_text_range(self) -> Optional[TextRange]:
-        if self.is_single_page_document:
+        if self.is_single_page_document and not DC.TOC_TREE in self.doc.capabilities:
             if self.doc.format == "txt":
                 return TextRange(0, len(self.doc))
             return None                


### PR DESCRIPTION
## Link to issue number:
closes #172 
### Summary of the issue:
Fixing the issue #168 caused a bug which would prevent other single page documents to be searched reliably.
### Description of how this pull request fixes the issue:
Essentially, single page documents that support table of contents, for example a HTML document or a word document will now handle document searching almost in the same way as non single page documents.
### Testing performed:
Manual testing
### Known issues with pull request:
None

@DraganRatkovich can you confirm that it works on your end?