### PR TITLE
Fix missing translation text in the advanced settings panel

### DIFF
--- a/bookworm/gui/settings.py
+++ b/bookworm/gui/settings.py
@@ -465,7 +465,7 @@ class AdvancedSettingsPanel(SettingsPanel):
             self.Bind(wx.EVT_BUTTON, self.onUpdatePandoc, updatePandocBtn)
         # Translators: the title of a group of controls in the
         # advanced settings page
-        advancedBox = self.make_static_box("Reset Settings ")
+        advancedBox = self.make_static_box(_("Reset Settings"))
         resetSettingsBtn = CommandLinkButton(
             advancedBox,
             -1,


### PR DESCRIPTION
## Link to issue number:
None
### Summary of the issue:
In the group box in the advanced settings panel, the labels were not translatable, I fixed it.
### Description of how this pull request fixes the issue:
Added missing underscores and parentheses to settings.py and that's it.
### Testing performed:
manual testing
### Known issues with pull request:

None