### PR TITLE
Fixed missing search results in moby documents without TOC

### DIFF
--- a/bookworm/document/formats/plain_text.py
+++ b/bookworm/document/formats/plain_text.py
@@ -8,6 +8,7 @@ from functools import cached_property
 import ftfy
 
 from bookworm.logger import logger
+from bookworm.structured_text import TextRange
 from bookworm.utils import (TextContentDecoder, normalize_line_breaks,
                             remove_excess_blank_lines)
 
@@ -35,11 +36,7 @@ class PlainTextDocument(SinglePageDocument):
         self.text = TextContentDecoder(content).get_utf8()
         super().read()
 
-    def __len__(self):
-        if self.text is None:
-            self.read()
-        return len(self.text)
-
+    
     def get_content(self):
         if len(self.text) > MAX_NUM_CHARS:
             return self.text
@@ -55,6 +52,7 @@ class PlainTextDocument(SinglePageDocument):
         return Section(
             title="",
             pager=Pager(first=0, last=0),
+            text_range=TextRange(0, len(self.get_content()))
         )
 
     @cached_property

--- a/bookworm/gui/components.py
+++ b/bookworm/gui/components.py
@@ -172,12 +172,9 @@ class PageRangeControl(sc.SizedPanel):
         return from_page, to_page
 
     def get_text_range(self) -> Optional[TextRange]:
-        if self.is_single_page_document and not DC.TOC_TREE in self.doc.capabilities:
-            if self.doc.format == "txt":
-                return TextRange(0, len(self.doc))
-            return None
         # #170: Search results were not showing for documents which had no TOC.
         # if there is only 1 section we assume that it is the full document and return its text range
+        # This actually turns out to fix #195 as well which was most likely a regression from the change that fixed the search results for text documents
         if len(self.doc) == 1:
             return self.doc.toc_tree.text_range
         if selected_item := self.sectionChoice.GetSelection():

--- a/bookworm/gui/components.py
+++ b/bookworm/gui/components.py
@@ -176,6 +176,10 @@ class PageRangeControl(sc.SizedPanel):
             if self.doc.format == "txt":
                 return TextRange(0, len(self.doc))
             return None
+        # #170: Search results were not showing for documents which had no TOC.
+        # if there is only 1 section we assume that it is the full document and return its text range
+        if len(self.doc) == 1:
+            return self.doc.toc_tree.text_range
         if selected_item := self.sectionChoice.GetSelection():
             section = self.sectionChoice.GetClientData(selected_item)
             start_pos, stop_pos = section.text_range


### PR DESCRIPTION
## Link to issue number:
fixes #170, fixes #195 
### Summary of the issue:
Bookworm would not show search results in moby documents which did not contain a TOC.
### Description of how this pull request fixes the issue:
Whenever the document misses a TOC we can assume that the toc_tree lenth will be always 1. As such when returning the text range we just obtain the text range of the root, which is the full document in that case.
### Testing performed:
Manual testing
### Known issues with pull request:
None
@DraganRatkovich can you confirm the issue is fixed in your end? If it is I will go ahead and merge.