### PR TITLE
Included "pinned/unpinned" phrases for translation

### DIFF
--- a/bookworm/gui/book_viewer/menubar.py
+++ b/bookworm/gui/book_viewer/menubar.py
@@ -239,11 +239,11 @@ class FileMenu(BaseMenu):
         if self.IsChecked(event.GetId()):
             recents_manager.pin(self.reader.document)
             sounds.pinning.play()
-            speech.announce("Pinned")
+            speech.announce(_("Pinned"))
         else:
             recents_manager.unpin(self.reader.document)
             sounds.pinning.play()
-            speech.announce("Unpinned")
+            speech.announce(_("Unpinned"))
         self.populate_pinned_documents_list()
 
     def onExportAsPlainText(self, event):

--- a/bookworm/resources/locale/ka/LC_MESSAGES/bookworm.po
+++ b/bookworm/resources/locale/ka/LC_MESSAGES/bookworm.po
@@ -7,8 +7,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Bookworm 2022.1b2\n"
 "Report-Msgid-Bugs-To: ibnomer2011@hotmail.com\n"
-"POT-Creation-Date: 2022-11-08 14:33+0000\n"
-"PO-Revision-Date: 2022-11-10 18:28+0400\n"
+"POT-Creation-Date: 2022-11-14 07:41+0000\n"
+"PO-Revision-Date: 2022-11-14 11:43+0400\n"
 "Last-Translator: Dragan Ratkovich\n"
 "Language-Team: Translation team of Dragan Ratkovich\n"
 "Language: ka\n"
@@ -2500,6 +2500,14 @@ msgstr "გამოსვლა"
 msgid "Select a document"
 msgstr "აირჩიეთ დოკუმენტი"
 
+#: bookworm/gui/book_viewer/menubar.py:242
+msgid "Pinned"
+msgstr "მიმაგრებულია"
+
+#: bookworm/gui/book_viewer/menubar.py:246
+msgid "Unpinned"
+msgstr "მოხსნილია"
+
 #. Translators: the title of a dialog showing
 #. the progress of book export process
 #: bookworm/gui/book_viewer/menubar.py:272
@@ -3446,7 +3454,7 @@ msgstr ""
 msgid "Download Completed"
 msgstr "ჩამოტვირთვა დასრულებულია"
 
-#: bookworm/platforms/win32/speech_engines/onecore.py:73
+#: bookworm/platforms/win32/speech_engines/onecore.py:74
 msgid "One-core Synthesizer"
 msgstr "One-core სინთეზატორი"
 
@@ -3533,22 +3541,22 @@ msgstr "წინ გადახვევა"
 msgid "End of document."
 msgstr "დოკუმენტის დასასრული."
 
-#: bookworm/text_to_speech/__init__.py:234
+#: bookworm/text_to_speech/__init__.py:235
 msgid "End of section: {chapter}."
 msgstr "{chapter} განყოფილების დასასრული."
 
 #. Translators: spoken message at the end of the document
-#: bookworm/text_to_speech/__init__.py:267
+#: bookworm/text_to_speech/__init__.py:268
 msgid "End of document"
 msgstr "დოკუმენტის დასასრული"
 
 #. Translators: the title of a message telling the user that no TTS voice found
-#: bookworm/text_to_speech/__init__.py:420
+#: bookworm/text_to_speech/__init__.py:421
 msgid "No TTS Voices"
 msgstr "არ არის TTS ხმა"
 
 #. Translators: a message telling the user that no TTS voice found
-#: bookworm/text_to_speech/__init__.py:422
+#: bookworm/text_to_speech/__init__.py:423
 msgid ""
 "A valid Text-to-speech voice was not found for the current speech engine.\n"
 "Text-to-speech functionality will be disabled."
@@ -3558,7 +3566,7 @@ msgstr ""
 "ტექსტის მეტყველებაში გადაყვანის ფუნქცია გამოირთვება."
 
 #. Translators: a message telling the user that the TTS voice has been changed
-#: bookworm/text_to_speech/__init__.py:440
+#: bookworm/text_to_speech/__init__.py:441
 msgid ""
 "Bookworm has noticed that the currently configured Text-to-speech voice "
 "speaks a language different from that of this book.\n"
@@ -3572,7 +3580,7 @@ msgstr ""
 
 #. Translators: the title of a message telling the user that the TTS voice has
 #. been changed
-#: bookworm/text_to_speech/__init__.py:447
+#: bookworm/text_to_speech/__init__.py:448
 msgid "Incompatible TTS Voice Detected"
 msgstr "აღმოჩენილია შეუთავსებელი TTS ხმა"
 
@@ -3681,7 +3689,6 @@ msgstr "მეტყველების სიჩქარე:"
 
 #. Translators: the label of the voice pitch slider
 #: bookworm/text_to_speech/tts_gui.py:160
-#| msgid "Voice Profiles"
 msgid "Voice Pitch:"
 msgstr "ხმის ტონი:"
 

--- a/bookworm/resources/locale/ru/LC_MESSAGES/bookworm.po
+++ b/bookworm/resources/locale/ru/LC_MESSAGES/bookworm.po
@@ -7,8 +7,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Bookworm 2022.1b2\n"
 "Report-Msgid-Bugs-To: ibnomer2011@hotmail.com\n"
-"POT-Creation-Date: 2022-11-08 14:33+0000\n"
-"PO-Revision-Date: 2022-11-10 11:41+0400\n"
+"POT-Creation-Date: 2022-11-14 07:41+0000\n"
+"PO-Revision-Date: 2022-11-14 11:45+0400\n"
 "Last-Translator: Dragan Ratkovich\n"
 "Language-Team: \n"
 "Language: ru\n"
@@ -2501,6 +2501,14 @@ msgstr "Выход"
 msgid "Select a document"
 msgstr "Выберите документ"
 
+#: bookworm/gui/book_viewer/menubar.py:242
+msgid "Pinned"
+msgstr "Закреплено"
+
+#: bookworm/gui/book_viewer/menubar.py:246
+msgid "Unpinned"
+msgstr "Откреплено"
+
 #. Translators: the title of a dialog showing
 #. the progress of book export process
 #: bookworm/gui/book_viewer/menubar.py:272
@@ -3447,7 +3455,7 @@ msgstr ""
 msgid "Download Completed"
 msgstr "Загрузка завершена"
 
-#: bookworm/platforms/win32/speech_engines/onecore.py:73
+#: bookworm/platforms/win32/speech_engines/onecore.py:74
 msgid "One-core Synthesizer"
 msgstr "One-core Синтезатор"
 
@@ -3534,22 +3542,22 @@ msgstr "Вперед"
 msgid "End of document."
 msgstr "Конец документа."
 
-#: bookworm/text_to_speech/__init__.py:234
+#: bookworm/text_to_speech/__init__.py:235
 msgid "End of section: {chapter}."
 msgstr "Конец раздела: {chapter}."
 
 #. Translators: spoken message at the end of the document
-#: bookworm/text_to_speech/__init__.py:267
+#: bookworm/text_to_speech/__init__.py:268
 msgid "End of document"
 msgstr "Конец документа"
 
 #. Translators: the title of a message telling the user that no TTS voice found
-#: bookworm/text_to_speech/__init__.py:420
+#: bookworm/text_to_speech/__init__.py:421
 msgid "No TTS Voices"
 msgstr "Нет голосов TTS"
 
 #. Translators: a message telling the user that no TTS voice found
-#: bookworm/text_to_speech/__init__.py:422
+#: bookworm/text_to_speech/__init__.py:423
 msgid ""
 "A valid Text-to-speech voice was not found for the current speech engine.\n"
 "Text-to-speech functionality will be disabled."
@@ -3559,7 +3567,7 @@ msgstr ""
 "Функция преобразования текста в речь будет отключена."
 
 #. Translators: a message telling the user that the TTS voice has been changed
-#: bookworm/text_to_speech/__init__.py:440
+#: bookworm/text_to_speech/__init__.py:441
 msgid ""
 "Bookworm has noticed that the currently configured Text-to-speech voice "
 "speaks a language different from that of this book.\n"
@@ -3573,7 +3581,7 @@ msgstr ""
 
 #. Translators: the title of a message telling the user that the TTS voice has
 #. been changed
-#: bookworm/text_to_speech/__init__.py:447
+#: bookworm/text_to_speech/__init__.py:448
 msgid "Incompatible TTS Voice Detected"
 msgstr "Обнаружен несовместимый голос TTS"
 
@@ -3683,7 +3691,6 @@ msgstr "Скорость речи:"
 
 #. Translators: the label of the voice pitch slider
 #: bookworm/text_to_speech/tts_gui.py:160
-#| msgid "Voice Profiles"
 msgid "Voice Pitch:"
 msgstr "Высота голоса:"
 


### PR DESCRIPTION
### Summary of the issue:
When pinning and unpinning documents, Bookworm announced UI messages in English only because the phrases were not included for translation.
### Description of how this pull request fixes the issue:
Added the necessary brackets to include the mentioned phrases for translation
### Testing performed:
Manual testing