### PR TITLE
Fixed encoding error in environment setup

### DIFF
--- a/bookworm/image_io.py
+++ b/bookworm/image_io.py
@@ -3,20 +3,20 @@
 from __future__ import annotations
 
 import io
+import importlib
 import tempfile
 from dataclasses import dataclass
 
 import fitz
 import wx
-from lazy_import import lazy_module
 from PIL import Image, ImageOps
 
 from bookworm import typehints as t
 from bookworm.logger import logger
+from bookworm.utils import lazy_module
 
 np = lazy_module("numpy")
 cv2 = lazy_module("cv2")
-
 
 log = logger.getChild(__name__)
 

--- a/bookworm/ocr_engines/image_processing_pipelines.py
+++ b/bookworm/ocr_engines/image_processing_pipelines.py
@@ -6,12 +6,13 @@ from abc import ABCMeta, abstractmethod
 from dataclasses import dataclass, field
 from io import BytesIO
 
-from lazy_import import lazy_module
 from PIL import Image, ImageEnhance, ImageOps
 
 from bookworm import typehints as t
 from bookworm.image_io import ImageIO
 from bookworm.logger import logger
+from bookworm.utils import lazy_module
+
 
 np = lazy_module("numpy")
 cv2 = lazy_module("cv2")

--- a/bookworm/utils/general.py
+++ b/bookworm/utils/general.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import contextlib
+import importlib
 import hashlib
 import os
 import sys
@@ -131,3 +132,7 @@ def format_datetime(
     return app.current_language.format_datetime(
         datetime_to_format, date_only=date_only, format=format, localized=localized
     )
+
+def lazy_module(mod: str):
+    module = importlib.__import__(mod)
+    return module

--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -24,7 +24,6 @@ ftfy==6.1.1
 fuzzywuzzy==0.18.0
 inscriptis==2.3.2
 languagecodes==1.0.7
-lazy_import==0.2.2
 Levenshtein==0.20.0
 libloader==0.21
 lru-dict==1.1.8


### PR DESCRIPTION
## Motivation
This PR fixes an encoding error during environment setup where the error cause happens to originate from the dependency lazy_import.
I have  removed the dependency, which appears to be unmaintained since 2018.
closes #228 
@cary-rowen do let me know if this solution works as expected.