### PR TITLE
Fix OSError by replacing os.link with os.symlink for cross-drive compatibility

### DIFF
--- a/bookworm/platforms/win32/speech_engines/piper/__init__.py
+++ b/bookworm/platforms/win32/speech_engines/piper/__init__.py
@@ -41,7 +41,9 @@ if IS_RUNNING_FROM_SOURCE:
             "pyper", "espeak-ng.dll"
         )
         if not espeak_dll_dst.exists():
-            os.link(espeak_ng_dll, espeak_dll_dst)
+            os.symlink(espeak_ng_dll, espeak_dll_dst)
+
+
 
 
 from ..utils import _audio_uri_to_filepath


### PR DESCRIPTION
## Link to issue number:
None
### Summary of the issue:
The `os.link` function was causing an `OSError` when attempting to create a hard link between different drives, preventing `invoke run` and `invoke bench` from executing properly.

### Description of how this pull request fixes the issue:
This pull request replaces the `os.link` function with `os.symlink` in the `bookworm/platforms/win32/speech_engines/piper/__init__.py` file. Unlike hard links, symbolic links can span across different drives, resolving the issue and allowing the commands to execute without errors.

### Testing performed:
Tested in an environment with the project directory and Python installation on separate drives. Verified that `invoke run` and `invoke bench` commands now execute successfully without encountering the `OSError`.

### Known issues with pull request:
None
