### PR TITLE
Fix appveyor error, Install Chocolatey if not already installed

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -16,8 +16,10 @@ environment:
     secure: "ogfTv7V0xR13ETjrC+koS7ZURfl0KLRfwcjYBexoiB1gcc5pppO/H42BopJWl0ua"
 
 install:
-  # Install hyperfine for benchmarking
-  - cinst hyperfine
+  # Install Chocolatey if not already installed
+  - powershell -NoProfile -InputFormat None -ExecutionPolicy Bypass -Command "iex ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1'))"
+  # Install hyperfine for benchmarking using Chocolatey
+  - choco install hyperfine
   # NSIS Paths
   # https://www.appveyor.com/docs/build-environment/#tools
   - set PATH=%PATH%;C:\Program Files (x86)\NSIS


### PR DESCRIPTION
## Link to issue number:

None

### Summary of the issue:

The AppVeyor build process failed because the `cinst` command was not recognized. This issue arose because Chocolatey was not installed or properly configured in the build environment, preventing the installation of the `hyperfine` tool, which is essential for running performance benchmarks.

### Description of how this pull request fixes the issue:

This pull request updates the `appveyor.yml` configuration to install Chocolatey before attempting to install `hyperfine`. By installing Chocolatey first, we ensure that the `choco install` command is available for installing `hyperfine`. This change allows the build scripts that rely on `hyperfine` to execute successfully.

### Testing performed:

Tested the updated `appveyor.yml` configuration in a clean AppVeyor environment to verify that Chocolatey installs correctly and that `hyperfine` can be installed and executed without issues. The build scripts that depend on `hyperfine` now run successfully.

### Known issues with pull request:
None