### PR TITLE
fix(epub): ensure date parsing handles non-string inputs gracefully

### DIFF
--- a/bookworm/document/formats/epub.py
+++ b/bookworm/document/formats/epub.py
@@ -82,8 +82,15 @@ class EpubDocument(SinglePageDocument):
             desc = HTMLParser(info.get("description", "")).text()
         except:
             desc = None
+        date_value = info.get("date", "")
+        if not isinstance(date_value, str):
+            log.warning(f"Unexpected date format: {type(date_value)}. Converting to string.")
+            if isinstance(date_value, (int, float)):
+                date_value = str(date_value)
+            else:
+                date_value = ""
         if pubdate := dateparser.parse(
-            info.get("date", ""),
+            date_value,
             languages=[
                 self.language.two_letter_language_code,
             ],
@@ -92,7 +99,7 @@ class EpubDocument(SinglePageDocument):
                 pubdate, date_only=True, format="long", localized=True
             )
         else:
-            publish_date = ""
+            publish_date = "Unknown Publication Date"
         return BookMetadata(
             title=self.epub.title,
             author=author.removeprefix("By ").strip(),


### PR DESCRIPTION
## Link to issue number:
None

### Summary of the issue:
When parsing the publication date in EPUB files, the `dateparser.parse` function can raise a `TypeError` if the date metadata is not provided as a string. This can cause the EPUB document to fail to load correctly.

### Description of how this pull request fixes the issue:
This pull request adds type checking and conversion for the publication date metadata before it is passed to `dateparser.parse`. If the date is not a string, it is converted to a string if possible, or set to an empty string. Additionally, if the date cannot be parsed, a default value of "Unknown Publication Date" is returned to ensure graceful handling.

### Testing performed:
- Manually tested with various EPUB files, including those with missing, numeric, and correctly formatted date fields.
- Verified that the EPUB files load correctly and that the metadata is handled as expected without raising exceptions.

### Known issues with pull request:
Unknown