### PR TITLE
Refactor to remove add_done_callback usage, ensuring safe passing of self.view as the parent to wx.MessageBox, resolving the issue of the dialog not appearing in the foreground.

### DIFF
--- a/bookworm/ocr/ocr_menu.py
+++ b/bookworm/ocr/ocr_menu.py
@@ -315,22 +315,25 @@ class OCRMenu(wx.Menu):
             target=self.service.current_ocr_engine.scan_to_text, args=args
         )
         progress_dlg.set_abort_callback(scan2text_process.cancel)
-        scan2text_process.add_done_callback(
-            wx.CallAfter,
-            wx.MessageBox,
-            _(
-                "Successfully processed {total} pages.\nExtracted text was written to: {file}"
-            ).format(total=total, file=output_file),
-            _("OCR Completed"),
-            wx.ICON_INFORMATION,
-        )
-        for progress in scan2text_process:
-            progress_dlg.Update(
-                progress + 1,
-                f"Scanning page {progress} of {total}",
+
+        try:
+            for progress in scan2text_process:
+                progress_dlg.Update(
+                    progress + 1,
+                    f"Scanning page {progress} of {total}",
+                )
+            wx.CallAfter(
+                wx.MessageBox,
+                message = _(
+                    "Successfully processed {total} pages.\nExtracted text was written to: {file}"
+                ).format(total=total, file=output_file),
+                caption = _("OCR Completed"),
+                style = wx.ICON_INFORMATION | wx.OK,
+                parent = self.view  # 设置 parent 确保对话框聚焦
             )
-        progress_dlg.Dismiss()
-        wx.CallAfter(self.view.contentTextCtrl.SetFocus)
+        finally:
+            progress_dlg.Dismiss()
+            wx.CallAfter(self.view.contentTextCtrl.SetFocus)
 
     def onChangeOCROptions(self, event):
         self._get_ocr_options(from_cache=False)


### PR DESCRIPTION
## Link to issue number:
Fixed #242

### Summary of the issue:
When using `scan2text_process.add_done_callback` to display a dialog after OCR processing, the `self.view` object could not be safely passed as the parent to the dialog. This resulted in the dialog not appearing in the foreground, causing screen reader users to be unaware that the dialog had appeared. As a result, they were unable to respond to the dialog and could not exit the application as expected.

### Description of how this pull request fixes the issue:
This PR refactors the code to directly use `wx.MessageBox` after the OCR process completes, rather than relying on `add_done_callback`. By doing this, `self.view` can be safely passed as the parent to `wx.MessageBox`, ensuring that the dialog appears in the foreground and is properly announced to screen reader users, allowing them to interact with the dialog and exit the application normally.

### Testing performed:
- Verified that the `wx.MessageBox` appears in the foreground with the correct parent (`self.view`) after OCR processing is completed.
- Confirmed that the dialog is properly announced by screen readers, enabling users to respond to it.
- Ensured that the dialog is correctly dismissed and that the focus returns to the main application window.
- Tested that the application remains responsive and that the OCR results are correctly processed and displayed.

### Known issues with pull request:
None identified at this time.
