### PR TITLE
Fix: Correct path passed to bootstrap.exe by using parent directory of app_path

### DIFF
--- a/bookworm/platforms/win32/updater.py
+++ b/bookworm/platforms/win32/updater.py
@@ -179,7 +179,7 @@ def execute_bootstrap(extraction_dir):
     log.info("Executing bootstrap to complete update.")
     move_to = extraction_dir.parent
     shutil.move(str(extraction_dir / "bootstrap.exe"), str(move_to))
-    args = f'"{os.getpid()}" "{extraction_dir}" "{paths.app_path()}" "{sys.executable}"'
+    args = f'"{os.getpid()}" "{extraction_dir}" "{Path(paths.app_path()).parent}" "{sys.executable}"'
     viewer = wx.GetApp().mainFrame
     if viewer.reader.ready:
         viewer.reader.save_current_position()


### PR DESCRIPTION
## Link to issue number:
None
### Summary of the issue:
Due to recent changes in PyInstaller,  `bootstrap.exe`  was receiving an incorrect path. Specifically,  `paths.app_path()`  was returning the  `_internal`  directory within the bookworm installation, instead of the expected main bookworm installation directory.
### Description of how this pull request fixes the issue:
This pull request modifies the path passed to `bootstrap.exe` by using the parent directory of `paths.app_path()`. This ensures that the correct bookworm installation directory is used, thereby resolving the update process issues.

### Testing performed:
- Verified that the update process completes successfully with the correct directory passed to `bootstrap.exe`.
- Checked the application behavior after the update to ensure there are no regressions.

### Known issues with pull request:
- None identified at this time.
