### PR TITLE
Disable Python optimizations temporarily in final release builds to preserve assert statements and runtime checks

### DIFF
--- a/tasks.py
+++ b/tasks.py
@@ -662,9 +662,15 @@ def freeze(c):
     with c.cd(str(PROJECT_ROOT / "scripts" / "builder")):
         if app.get_version_info()["pre_type"] is None:
             print(
-                "The current build is a final release. Turnning on python optimizations..."
+                "Final release detected. Python optimizations are currently disabled "
+                "to ensure assert statements and runtime checks are preserved."
+                " This is a temporary measure, and we plan to enable optimizations in future versions."
             )
-            os.environ["PYTHONOPTIMIZE"] = "2"
+            # TODO: Python optimization mode is commented out to prevent removal of assert statements
+            # in production builds. Assert statements are crucial for ensuring runtime checks,
+            # and omitting them could lead to unexpected behavior or failures.
+            # To revisit: Determine how to handle optimizations without impacting critical runtime checks.
+            # os.environ["PYTHONOPTIMIZE"] = "2"
         c.run(
             f"pyinstaller Bookworm.spec --clean -y --distpath {c['build_folder'].parent}",
             hide=False,


### PR DESCRIPTION
## Link to issue number:
This change addresses the handling of Python optimization in final release builds.

### Summary of the issue:
In previous builds, Python’s optimization mode was automatically activated for final releases, which resulted in the removal of `assert` statements. This led to the omission of critical runtime checks in the production environment, potentially causing unexpected behavior or failure in the application.

### Description of how this pull request fixes the issue:
This pull request disables Python’s optimization mode in final release builds to ensure that `assert` statements and important runtime checks are preserved. Although optimizations are typically desired for final releases, this is a temporary measure until we can implement a more robust way of handling runtime checks without relying on `assert` statements. Clear messaging has also been added to indicate that optimization will be revisited in future versions.

### Testing performed:
Manual testing of the build process confirmed that Python optimizations are no longer applied, and the `assert` statements remain active, even in final release versions. The program runs successfully with the critical checks intact.

### Known issues with pull request:
None currently known, but future work will involve reevaluating how to enable optimizations while maintaining necessary runtime validations.
