### PR TITLE
Fix stable channel handling and enable release candidate (rc) channel, remove dev channel

### DIFF
--- a/bookworm/otau.py
+++ b/bookworm/otau.py
@@ -28,7 +28,9 @@ class UpdateChannel(RootModel[str]):
     @field_validator("root")
     @classmethod
     def validate_identifier(cls, v: str):
-        if v not in ["", "b", "a", "dev"]:
+        if v is None:
+            v = ""
+        if v not in ["", "b", "a", "rc"]:
             raise TypeError("Unrecognized release identifier")
         return v
 
@@ -61,6 +63,8 @@ class UpdateInfo(RootModel[t.Dict[UpdateChannel, VersionInfo]]):
         return tuple(self.root.keys())
 
     def get_update_info_for_channel(self, channel_identifier: str) -> VersionInfo:
+        if channel_identifier is None:
+            channel_identifier = ""
         return self.root.get(UpdateChannel.model_validate(channel_identifier))
 
 


### PR DESCRIPTION
## Link to issue number:

N/A

### Summary of the issue:

The handling of versions without a pre-release channel (which should be treated as stable) had some gaps. The dev channel has been removed, and the release candidate (rc) channel has been enabled.

### Description of how this pull request fixes the issue:

This pull request ensures that versions without a pre-release channel are correctly treated as stable. The dev channel has been removed, and the release candidate (rc) channel has been enabled.

### Testing performed:

- Verified that stable versions (without a pre-release channel) are correctly handled.
- Confirmed that the dev channel has been removed.
- Tested with beta (b), alpha (a), and release candidate (rc) channels to ensure proper update handling.

### Known issues with pull request:

No known issues.
