### PR TITLE
Added Spanish translation

### DIFF
--- a/bookworm/resources/locale/es/LC_MESSAGES/bookworm.po
+++ b/bookworm/resources/locale/es/LC_MESSAGES/bookworm.po
@@ -1,217 +1,302 @@
-# Spanish translations for PROJECT.
-# Copyright (C) 2019 Musharraf Omer
-# This file is distributed under the same license as the PROJECT project.
-# FIRST AUTHOR <EMAIL@ADDRESS>, 2019.
+# Translations template for Bookworm.
+# Copyright (C) 2022 Blind Pandas
+# This file is distributed under the same license as the Bookworm project.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2022.
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: PROJECT VERSION\n"
+"Project-Id-Version: Bookworm 2022.1a5\n"
 "Report-Msgid-Bugs-To: ibnomer2011@hotmail.com\n"
-"POT-Creation-Date: 2021-05-19 15:31+0200\n"
-"PO-Revision-Date: 2019-12-11 23:00-0600\n"
-"Last-Translator: \n"
+"POT-Creation-Date: 2024-12-01 09:01+0100\n"
+"PO-Revision-Date: 2024-12-01 09:18+0100\n"
+"Last-Translator: Juan C. Buño <oprisniki@gmail.com>\n"
+"Language-Team: \n"
 "Language: es\n"
-"Language-Team: es <LL@li.org>\n"
-"Plural-Forms: nplurals=2; plural=(n != 1)\n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=utf-8\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "Generated-By: Babel 2.9.1\n"
+"X-Generator: Poedit 3.5\n"
 
 #. Translators: the content of a message indicating a connection error
-#: bookworm/otau.py:76
+#: bookworm/otau.py:82
 msgid "We couldn't access the internet right now. Please try again later."
 msgstr ""
-"No se puede acceder a Internet en estos momentos. Por favor, inténtelo "
-"más tarde."
+"No podemos acceder a Internet en este momento. Vuelva a intentarlo más tarde."
 
 #. Translators: the title of a message indicating a connection error
-#: bookworm/otau.py:78
+#. Translators: the title of a message indicating a failure in downloading an
+#. update
+#: bookworm/otau.py:84 bookworm/platforms/win32/updater.py:119
 msgid "Network Error"
-msgstr "Eror de Red"
+msgstr "Error de Red"
 
 #. Translators: the content of a message indicating an error while updating the
 #. app
-#: bookworm/otau.py:88
+#: bookworm/otau.py:94
 msgid ""
 "We have faced a technical problem while checking for updates. Please try "
 "again later."
 msgstr ""
-"Estamos teniendo problemas al buscar actualizaciones. Por favor, "
-"inténtelo más tarde."
+"Se ha producido un problema técnico al comprobar las actualizaciones. Vuelva "
+"a intentarlo más tarde."
 
 #. Translators: the title of a message indicating an error while updating the
 #. app
-#: bookworm/otau.py:92
+#: bookworm/otau.py:98
 msgid "Error Checking For Updates"
-msgstr "Error buscando actualizaciones"
+msgstr "Comprobación de errores en las actualizaciones"
 
 #. Translators: the content of a message indicating that there is no new
 #. version
-#: bookworm/otau.py:107
+#: bookworm/otau.py:115
 msgid ""
 "Congratulations, you have already got the latest version of Bookworm.\n"
-"We are working day and night on making Bookworm better. The next version "
-"of Bookworm is on its way, so wait for it. Rest assured, we will notify "
-"you when it is released."
+"We are working day and night on making Bookworm better. The next version of "
+"Bookworm is on its way, so wait for it. Rest assured, we will notify you "
+"when it is released."
 msgstr ""
-"Felicitaciones, usted ya tiene la versión más reciente de Bookworm.\n"
-"Trabajamos día y noche en mejorar Bookworm. La siguiente versión de "
-"Bookworm va en camino, así que, por favor espere. Duerma tranquilo, le "
-"notificaremos cuando esté lista."
+"Enhorabuena, ya tienes la última versión de Bookworm.\n"
+"Estamos trabajando día y noche para mejorar Bookworm. La próxima versión de "
+"Bookworm está en camino, así que espérala. Ten por seguro que te avisaremos "
+"cuando esté disponible."
 
 #. Translators: the title of a message indicating that there is no new version
-#: bookworm/otau.py:114
+#: bookworm/otau.py:122
 msgid "No Update"
-msgstr "No hay actualizaciones"
+msgstr "Sin Actualizar"
 
 #. Translators: the label of an item in the application menubar
-#: bookworm/otau.py:139
+#: bookworm/otau.py:147
 msgid "&Check for updates"
-msgstr "&Buscar actualizaciones"
+msgstr "&Comprobar Actualizaciones"
 
 #. Translators: the help text of an item in the application menubar
-#: bookworm/otau.py:141
+#: bookworm/otau.py:149
 msgid "Update the application"
-msgstr "Actualiza la aplicación"
+msgstr "Actualizar la aplicación"
 
 #. Translators: the title of the window when an e-book is open
-#: bookworm/reader.py:309
+#: bookworm/reader.py:439
 msgid "{title} — by {author}"
 msgstr "{title} — por {author}"
 
-#: bookworm/annotation/__init__.py:64
-msgid "&Bookmark...\tCtrl-B"
-msgstr ""
+#. Translators: title of a message dialog that shows a table as html document
+#: bookworm/reader.py:456
+msgid "Table View"
+msgstr "Vista de Tabla"
 
-#: bookworm/annotation/__init__.py:65 bookworm/annotation/__init__.py:71
-msgid "Bookmark the current location"
-msgstr "Marca la ubicación actual"
-
-#: bookworm/annotation/__init__.py:70
-msgid "&Named Bookmark...\tCtrl-Shift-B"
-msgstr ""
-
-#: bookworm/annotation/__init__.py:76
-msgid "Co&mment...\tCtrl-m"
-msgstr ""
+#. Translators: the label of an item in the application menubar
+#: bookworm/annotation/__init__.py:69
+msgid "&Annotation"
+msgstr "A&notación"
 
 #: bookworm/annotation/__init__.py:77
+msgid "&Bookmark...\tCtrl-B"
+msgstr "&Marcas...\tCtrl-B"
+
+#: bookworm/annotation/__init__.py:78 bookworm/annotation/__init__.py:84
+msgid "Bookmark the current location"
+msgstr "Marcar la posición actual"
+
+#: bookworm/annotation/__init__.py:83
+msgid "&Named Bookmark...\tCtrl-Shift-B"
+msgstr "&Nombrar Marca...\tCtrl-Shift-B"
+
+#: bookworm/annotation/__init__.py:89
+msgid "Co&mment...\tCtrl-m"
+msgstr "&Comentario...\tCtrl-m"
+
+#: bookworm/annotation/__init__.py:90
 msgid "Add a comment at the current location"
-msgstr ""
+msgstr "Añadir un comentario en la posición actual"
 
-#: bookworm/annotation/__init__.py:87
+#: bookworm/annotation/__init__.py:100
 msgid "Highlight Selection\tCtrl-Shift-H"
-msgstr ""
+msgstr "Resaltar Selección\tCtrl-Shift-H"
 
-#: bookworm/annotation/__init__.py:88
+#: bookworm/annotation/__init__.py:101
 msgid "Highlight and save selected text."
-msgstr ""
+msgstr "Resaltar y guardar el texto seleccionado."
 
 #. Translators: the label of a button in the application toolbar
 #. Translators: spoken message when jumping to a bookmark
-#: bookworm/annotation/__init__.py:97 bookworm/annotation/__init__.py:132
+#: bookworm/annotation/__init__.py:110 bookworm/annotation/__init__.py:147
 msgid "Bookmark"
-msgstr "Marcador"
+msgstr "Marca"
 
 #. Translators: the label of a button in the application toolbar
-#: bookworm/annotation/__init__.py:99
+#: bookworm/annotation/__init__.py:112
 msgid "Comment"
-msgstr ""
+msgstr "Comentario"
 
 #. Translators: the label of a page in the settings dialog
-#. Translators: the title of a group of controls in the
 #. Translators: label for a aria region containing annotation
 #. used when exporting annotations to HTML
-#: bookworm/annotation/__init__.py:109 bookworm/annotation/annotation_gui.py:26
-#: bookworm/annotation/exporters/core_renderers.py:169
+#: bookworm/annotation/__init__.py:122
+#: bookworm/annotation/exporters/core_renderers.py:171
 msgid "Annotation"
-msgstr ""
+msgstr "Anotación"
+
+#. Translators: spoken message
+#: bookworm/annotation/__init__.py:135
+msgid "No next bookmark"
+msgstr "No hay marca siguiente"
+
+#. Translators: spoken message
+#: bookworm/annotation/__init__.py:138
+msgid "No previous bookmark"
+msgstr "No hay marca anterior"
+
+#. Translators: spoken message
+#: bookworm/annotation/__init__.py:165
+msgid "No next comment"
+msgstr "No hay comentario siguiente"
+
+#. Translators: spoken message
+#: bookworm/annotation/__init__.py:168
+msgid "No previous comment"
+msgstr "No hay comentario anterior"
+
+#. Translators: spoken message when jumping to a comment
+#: bookworm/annotation/__init__.py:179
+msgid "Comment: {comment}"
+msgstr "Comentario: {comment}"
+
+#. Translators: spoken message
+#: bookworm/annotation/__init__.py:192
+msgid "No next highlight"
+msgstr "No hay resaltado siguiente"
+
+#. Translators: spoken message
+#: bookworm/annotation/__init__.py:195
+msgid "No previous highlight"
+msgstr "No hay resaltado anterior"
+
+#: bookworm/annotation/__init__.py:205
+msgid "Highlight"
+msgstr "Resaltado"
+
+#. Translators: spoken message indicating the presence of an annotation when
+#. the user navigates the text
+#: bookworm/annotation/__init__.py:247
+msgid "Bookmarked"
+msgstr "Marcado"
+
+#. Translators: spoken message indicating the presence of an annotation when
+#. the user navigates the text
+#: bookworm/annotation/__init__.py:250
+msgid "Highlighted"
+msgstr "Resaltado"
+
+#. Translators: spoken message indicating the presence of an annotation when
+#. the user navigates the text
+#: bookworm/annotation/__init__.py:253
+msgid "Line contains highlight"
+msgstr "La línea contiene resaltado"
+
+#. Translators: spoken message indicating the presence of an annotation when
+#. the user navigates the text
+#: bookworm/annotation/__init__.py:256
+msgid "Has comment"
+msgstr "Tiene comentario"
 
 #. Translators: label of an edit control in the dialog
 #. of viewing or editing a comment/highlight
 #. Translators: label of an edit control to filter annotations by content
+#. Translators: label of a check box that enables/disables searching document
+#. content when searching the bookshelf
 #. Translators: the label of the text area which shows the
 #. content of the current page
-#: bookworm/annotation/annotation_dialogs.py:63
-#: bookworm/annotation/annotation_dialogs.py:270
-#: bookworm/gui/book_viewer/__init__.py:245
+#: bookworm/annotation/annotation_dialogs.py:59
+#: bookworm/annotation/annotation_dialogs.py:266
+#: bookworm/bookshelf/local_bookshelf/dialogs.py:126
+#: bookworm/gui/book_viewer/__init__.py:317
 msgid "Content"
 msgstr "Contenido"
 
 #. Translators: header of a group of controls in a dialog to view/edit
 #. comments/highlights
-#: bookworm/annotation/annotation_dialogs.py:67
+#: bookworm/annotation/annotation_dialogs.py:63
 msgid "Metadata"
-msgstr ""
+msgstr "Metadatos"
 
 #. Translators: label of an edit control in a dialog to view/edit
 #. comments/highlights
 #. Translators: label of an edit control that allows the user to edit the tag
 #. set of a comment/highlight
 #. Translators: written to output document when exporting a comment/highlight
-#: bookworm/annotation/annotation_dialogs.py:70
-#: bookworm/annotation/annotation_dialogs.py:526
-#: bookworm/annotation/exporters/core_renderers.py:199
+#: bookworm/annotation/annotation_dialogs.py:66
+#: bookworm/annotation/annotation_dialogs.py:522
+#: bookworm/annotation/exporters/core_renderers.py:201
 msgid "Tags"
-msgstr ""
+msgstr "Etiquetas"
 
 #. Translators: label of an edit control in a dialog to view/edit
 #. comments/highlights
-#: bookworm/annotation/annotation_dialogs.py:75
+#: bookworm/annotation/annotation_dialogs.py:71
 msgid "Date Created"
-msgstr ""
+msgstr "Fecha de Creación"
 
 #. Translators: label of an edit control in a dialog to view/edit
 #. comments/highlights
-#: bookworm/annotation/annotation_dialogs.py:81
+#: bookworm/annotation/annotation_dialogs.py:77
 msgid "Last updated"
-msgstr ""
+msgstr "Última actualización"
 
 #. Translators: the label of a button to close a dialog
+#. Translators: the label of the cancel button in a dialog
+#. Translators: the label of the close button in a dialog
 #. Translators: the label of a button to close the dialog
-#: bookworm/annotation/annotation_dialogs.py:95
-#: bookworm/annotation/annotation_dialogs.py:152 bookworm/gui/settings.py:98
-#: bookworm/ocr/ocr_dialogs.py:332 bookworm/text_to_speech/tts_gui.py:328
-#: bookworm/webservices/wikiworm.py:177
+#: bookworm/annotation/annotation_dialogs.py:91
+#: bookworm/annotation/annotation_dialogs.py:148
+#: bookworm/bookshelf/local_bookshelf/dialogs.py:177
+#: bookworm/bookshelf/local_bookshelf/dialogs.py:245
+#: bookworm/gui/book_viewer/core_dialogs.py:407 bookworm/gui/settings.py:147
+#: bookworm/ocr/ocr_dialogs.py:428 bookworm/text_to_speech/tts_gui.py:331
+#: bookworm/webservices/wikiworm.py:215
 msgid "&Close"
-msgstr "Cerrar"
+msgstr "&Cerrar"
 
 #. Translators: label for unnamed bookmarks shown
 #. when editing a single bookmark which has no name
-#: bookworm/annotation/annotation_dialogs.py:129
-#, fuzzy
+#: bookworm/annotation/annotation_dialogs.py:125
 msgid "[Unnamed Bookmark]"
-msgstr "Muestra los marcadores añadidos."
+msgstr "[Marca sin Nombre]"
 
 #. Translators: label of a list control containing bookmarks
-#: bookworm/annotation/annotation_dialogs.py:134
+#: bookworm/annotation/annotation_dialogs.py:130
 msgid "Saved Bookmarks"
-msgstr ""
+msgstr "Marcas guardadas"
 
 #. Translators: text of a button to remove bookmarks
 #. Translators: text of a button to remove a language from Tesseract OCR Engine
 #. Translators: the label of a button to remove a voice profile
-#: bookworm/annotation/annotation_dialogs.py:137
-#: bookworm/ocr/ocr_dialogs.py:313 bookworm/text_to_speech/tts_gui.py:322
+#: bookworm/annotation/annotation_dialogs.py:133
+#: bookworm/ocr/ocr_dialogs.py:467 bookworm/text_to_speech/tts_gui.py:325
 msgid "&Remove"
 msgstr "&Eliminar"
 
 #. Translators: the title of a column in the bookmarks list
-#: bookworm/annotation/annotation_dialogs.py:161
+#: bookworm/annotation/annotation_dialogs.py:157
+#: bookworm/gui/book_viewer/core_dialogs.py:265
 msgid "Name"
-msgstr ""
+msgstr "Nombre"
 
 #. Translators: the title of a column in the bookmarks list
 #. Translators: text of a toggle button to sort comments/highlights list
+#. Translators: header of a column in a list control in a dialog showing a list
+#. of search results of matching document pages
 #. Translators: the title of a column in the search results list
 #. Translators: the label of the image of a page in a dialog to render the
 #. current page
-#: bookworm/annotation/annotation_dialogs.py:168
-#: bookworm/annotation/annotation_dialogs.py:359
-#: bookworm/annotation/exporters/core_renderers.py:176
-#: bookworm/gui/book_viewer/core_dialogs.py:42
-#: bookworm/gui/book_viewer/render_view.py:57
+#: bookworm/annotation/annotation_dialogs.py:164
+#: bookworm/annotation/annotation_dialogs.py:355
+#: bookworm/annotation/exporters/core_renderers.py:178
+#: bookworm/bookshelf/local_bookshelf/dialogs.py:196
+#: bookworm/gui/book_viewer/core_dialogs.py:60
+#: bookworm/gui/book_viewer/render_view.py:32
 msgid "Page"
 msgstr "Página"
 
@@ -219,2267 +304,3634 @@ msgstr "Página"
 #. Translators: label of an editable combobox to filter annotations by section
 #. Translators: the title of a column in the search results list
 #. showing the title of the chapter in which this occurrence was found
-#: bookworm/annotation/annotation_dialogs.py:176
-#: bookworm/annotation/annotation_dialogs.py:265
-#: bookworm/annotation/exporters/core_renderers.py:143
-#: bookworm/gui/book_viewer/core_dialogs.py:57
+#: bookworm/annotation/annotation_dialogs.py:172
+#: bookworm/annotation/annotation_dialogs.py:261
+#: bookworm/annotation/exporters/core_renderers.py:145
+#: bookworm/gui/book_viewer/core_dialogs.py:75
 msgid "Section"
 msgstr "Sección"
 
 #. Translators: content of a message asking the user if they want to delete a
 #. bookmark
-#: bookworm/annotation/annotation_dialogs.py:223
+#: bookworm/annotation/annotation_dialogs.py:219
 msgid ""
 "This action can not be reverted.\r\n"
 "Are you sure you want to remove this bookmark?"
 msgstr ""
+"Esta acción no se puede revertir.\n"
+"Estás seguro de que quieres eliminar esta marca?"
 
 #. Translators: title of a message asking the user if they want to delete a
 #. bookmark
-#: bookworm/annotation/annotation_dialogs.py:227
+#: bookworm/annotation/annotation_dialogs.py:223
 msgid "Remove Bookmark?"
-msgstr ""
+msgstr "¿Eliminar Marca?"
 
 #. Translators: label of an editable combobox to filter annotations by book
 #. Translators: text of a toggle button to sort comments/highlights list
-#: bookworm/annotation/annotation_dialogs.py:254
-#: bookworm/annotation/annotation_dialogs.py:363
-#: bookworm/annotation/annotation_dialogs.py:559
-#: bookworm/annotation/exporters/core_renderers.py:141
+#: bookworm/annotation/annotation_dialogs.py:250
+#: bookworm/annotation/annotation_dialogs.py:359
+#: bookworm/annotation/annotation_dialogs.py:555
+#: bookworm/annotation/exporters/core_renderers.py:143
 msgid "Book"
-msgstr ""
+msgstr "Libro"
 
 #. Translators: label of an editable combobox to filter annotations by tag
-#: bookworm/annotation/annotation_dialogs.py:259
-#: bookworm/annotation/exporters/core_renderers.py:145
+#: bookworm/annotation/annotation_dialogs.py:255
+#: bookworm/annotation/exporters/core_renderers.py:147
 msgid "Tag"
-msgstr ""
+msgstr "Etiqueta"
 
 #. Translators: text of a button to apply chosen filters in a dialog to view
 #. user's comments/highlights
-#: bookworm/annotation/annotation_dialogs.py:275
+#: bookworm/annotation/annotation_dialogs.py:271
 msgid "&Apply"
-msgstr ""
+msgstr "&Aplicar"
 
 #. Translators: the title of a column in the comments/highlights list
 #. Translators: header of a group of controls in a dialog to view user's
 #. comments/highlights
-#: bookworm/annotation/annotation_dialogs.py:342
+#: bookworm/annotation/annotation_dialogs.py:338
 msgid "Filter By"
-msgstr ""
+msgstr "Filtrar Por"
 
 #. Translators: header of a group of controls in a dialog to view user's
 #. comments/highlights
-#: bookworm/annotation/annotation_dialogs.py:351
+#: bookworm/annotation/annotation_dialogs.py:347
 msgid "Sort By"
-msgstr ""
+msgstr "Ordenar Por"
 
 #. Translators: text of a toggle button to sort comments/highlights list
-#: bookworm/annotation/annotation_dialogs.py:357
+#: bookworm/annotation/annotation_dialogs.py:353
 msgid "Date"
-msgstr ""
+msgstr "Fecha"
 
 #. Translators: text of a toggle button to sort comments/highlights list
-#: bookworm/annotation/annotation_dialogs.py:369
+#: bookworm/annotation/annotation_dialogs.py:365
 msgid "Ascending"
-msgstr ""
+msgstr "Ascendente"
 
 #. Translators: text of a button in a dialog to view comments/highlights
-#: bookworm/annotation/annotation_dialogs.py:378
+#: bookworm/annotation/annotation_dialogs.py:374
 msgid "&View..."
-msgstr ""
+msgstr "&Ver..."
 
 #. Translators: text of a button in a dialog to view comments/highlights
 #. Translators: the label of a button to edit a voice profile
-#: bookworm/annotation/annotation_dialogs.py:381
-#: bookworm/text_to_speech/tts_gui.py:320
+#: bookworm/annotation/annotation_dialogs.py:377
+#: bookworm/text_to_speech/tts_gui.py:323
 msgid "&Edit..."
 msgstr "&Editar..."
 
 #. Translators: text of a button in a dialog to view comments/highlights
-#: bookworm/annotation/annotation_dialogs.py:384
+#: bookworm/annotation/annotation_dialogs.py:380
 msgid "&Delete..."
-msgstr ""
+msgstr "E&liminar..."
 
 #. Translators: text of a button in a dialog to view comments/highlights
-#: bookworm/annotation/annotation_dialogs.py:386
+#: bookworm/annotation/annotation_dialogs.py:382
 msgid "E&xport..."
-msgstr ""
+msgstr "E&xportar..."
 
 #. Translators: title of a dialog to view or edit a single comment/highlight
-#: bookworm/annotation/annotation_dialogs.py:458
-#, fuzzy
+#: bookworm/annotation/annotation_dialogs.py:454
 msgid "Editing"
-msgstr "Lectura"
+msgstr "Editando"
 
-#: bookworm/annotation/annotation_dialogs.py:458
+#: bookworm/annotation/annotation_dialogs.py:454
 msgid "View"
-msgstr "Vista"
+msgstr "Ver"
 
 #. Translators: content of a message asking the user if they want to delete a
 #. comment/highlight
-#: bookworm/annotation/annotation_dialogs.py:475
+#: bookworm/annotation/annotation_dialogs.py:471
 msgid ""
 "This action can not be reverted.\r\n"
 "Are you sure you want to remove this item?"
 msgstr ""
+"Esta acción no se puede revertir.\n"
+"Estás seguro de que deseas eliminar este elemento?"
 
 #. Translators: title of a message asking the user if they want to delete a
 #. bookmark
-#: bookworm/annotation/annotation_dialogs.py:479
+#: bookworm/annotation/annotation_dialogs.py:475
 msgid "Delete Annotation?"
-msgstr ""
+msgstr "¿Eliminar Anotación?"
 
 #. Translators: title of a dialog that allows the user to edit the tag set of a
 #. comment/highlight
-#: bookworm/annotation/annotation_dialogs.py:524
+#: bookworm/annotation/annotation_dialogs.py:520
 msgid "Edit Tags"
-msgstr ""
+msgstr "Editar Etiquetas"
 
 #. Translators: title of a dialog that allows the user to customize
 #. how comments/highlights are exported
-#: bookworm/annotation/annotation_dialogs.py:537
+#: bookworm/annotation/annotation_dialogs.py:533
 msgid "Export Options"
-msgstr ""
+msgstr "Opciones de Exportar"
 
 #. Translators: label of a checkbox in a dialog to set export options for
 #. comments/highlights
-#: bookworm/annotation/annotation_dialogs.py:597
+#: bookworm/annotation/annotation_dialogs.py:593
 msgid "Include book title"
-msgstr ""
+msgstr "Incluir título del libro"
 
-#: bookworm/annotation/annotation_dialogs.py:602
+#: bookworm/annotation/annotation_dialogs.py:598
 msgid "Include section title"
-msgstr ""
+msgstr "Incluir título de sección"
 
-#: bookworm/annotation/annotation_dialogs.py:608
+#: bookworm/annotation/annotation_dialogs.py:604
 msgid "Include  page number"
-msgstr ""
+msgstr "Incluir número de página"
 
 #. Translators: label of a checkbox in a dialog to set export options for
 #. comments/highlights
-#: bookworm/annotation/annotation_dialogs.py:611
+#: bookworm/annotation/annotation_dialogs.py:607
 msgid "Include tags"
-msgstr ""
+msgstr "Incluir etiquetas"
 
 #. Translators: label of a choice control in a dialog to set export options for
 #. comments/highlights
-#: bookworm/annotation/annotation_dialogs.py:613
+#: bookworm/annotation/annotation_dialogs.py:609
 msgid "Output format:"
-msgstr "Formato de salida"
+msgstr "Formato de salida:"
 
 #. Translators: label of an edit control in a dialog to set export options for
 #. comments/highlights
-#: bookworm/annotation/annotation_dialogs.py:618
+#: bookworm/annotation/annotation_dialogs.py:614
 msgid "Output File"
-msgstr ""
+msgstr "Fichero de Salida"
 
 #. Translators: text of a button in a dialog to set export options for
 #. comments/highlights
-#: bookworm/annotation/annotation_dialogs.py:623
+#: bookworm/annotation/annotation_dialogs.py:619
 msgid "&Browse"
-msgstr ""
+msgstr "&Examinar"
 
 #. Translators: label of a checkbox in a dialog to set export options for
 #. comments/highlights
-#: bookworm/annotation/annotation_dialogs.py:628
+#: bookworm/annotation/annotation_dialogs.py:624
 msgid "Open file after exporting"
-msgstr "Abrir archivo tras la exportación"
+msgstr "Abrir fichero tras exportar"
 
 #. Translators: the title of a save file dialog asking the user for a filename
 #. to export annotations to
 #. Translators: the title of a dialog to save the exported book
-#: bookworm/annotation/annotation_dialogs.py:655
-#: bookworm/gui/book_viewer/menubar.py:221
+#: bookworm/annotation/annotation_dialogs.py:651
+#: bookworm/gui/book_viewer/menubar.py:253
 msgid "Save As"
-msgstr "Guardar como"
+msgstr "Guardar Como"
+
+#. Translators: the title of a group of controls in the settings dialog
+#: bookworm/annotation/annotation_gui.py:28
+msgid "When navigating text"
+msgstr "Al navegar por el texto"
 
 #. Translators: the label of a checkbox
-#: bookworm/annotation/annotation_gui.py:31
-msgid "Exclude named bookmarks when jumping between bookmarks"
-msgstr ""
+#: bookworm/annotation/annotation_gui.py:33
+msgid "Play a sound to indicate the presence of annotations"
+msgstr "Reproduce un sonido para indicar la presencia  de anotaciones"
 
 #. Translators: the label of a checkbox
-#: bookworm/annotation/annotation_gui.py:38
+#: bookworm/annotation/annotation_gui.py:40
+msgid "Speak a message to indicate the presence of annotations"
+msgstr "Vervaliza un mensaje para indicar la presencia de anotaciones"
+
+#. Translators: the title of a group of controls in the settings dialog
+#: bookworm/annotation/annotation_gui.py:44
+msgid "Miscellaneous settings"
+msgstr "Opciones de miscelánea"
+
+#. Translators: the label of a checkbox
+#: bookworm/annotation/annotation_gui.py:49
 msgid "Speak the bookmark when jumping"
-msgstr ""
+msgstr "Verbalizar la marca al saltar"
 
 #. Translators: the label of a checkbox
-#: bookworm/annotation/annotation_gui.py:45
+#: bookworm/annotation/annotation_gui.py:56
 msgid "Select the bookmarked line when jumping"
-msgstr ""
+msgstr "Seleccionar la línea marcada al saltar"
 
 #. Translators: the label of a checkbox
-#: bookworm/annotation/annotation_gui.py:52
+#: bookworm/annotation/annotation_gui.py:63
 msgid "Use visual styles to indicate annotations"
-msgstr ""
-
-#. Translators: the label of a checkbox
-#: bookworm/annotation/annotation_gui.py:59
-msgid "Use sounds to indicate the presence of comments"
-msgstr ""
+msgstr "Utilizar estilos visuales para indicar anotaciones"
 
 #. Translators: the label of an item in the application menubar
-#: bookworm/annotation/annotation_gui.py:99
+#: bookworm/annotation/annotation_gui.py:102
 msgid "Add &Bookmark\tCtrl-B"
-msgstr ""
+msgstr "Añadir &Marca\tCtrl-B"
 
 #. Translators: the help text of an item in the application menubar
-#: bookworm/annotation/annotation_gui.py:101
+#: bookworm/annotation/annotation_gui.py:104
 msgid "Add a bookmark at the current position"
-msgstr ""
+msgstr "Añade una marca en la posición actual"
 
 #. Translators: the label of an item in the application menubar
-#: bookworm/annotation/annotation_gui.py:106
+#: bookworm/annotation/annotation_gui.py:109
 msgid "Add &Named Bookmark...\tCtrl-Shift-B"
-msgstr ""
+msgstr "Añadir Marca con &Nombre...\tCtrl-Shift-B"
 
 #. Translators: the help text of an item in the application menubar
-#: bookworm/annotation/annotation_gui.py:108
+#: bookworm/annotation/annotation_gui.py:111
 msgid "Add a named bookmark at the current position"
-msgstr ""
+msgstr "Añade una marca con nombre en la posición actual"
 
 #. Translators: the label of an item in the application menubar
-#: bookworm/annotation/annotation_gui.py:113
+#: bookworm/annotation/annotation_gui.py:116
 msgid "Add Co&mment...\tCtrl-M"
-msgstr ""
+msgstr "Añadir &Comentario...\tCtrl-M"
 
 #. Translators: the help text of an item in the application menubar
-#: bookworm/annotation/annotation_gui.py:115
+#: bookworm/annotation/annotation_gui.py:118
 msgid "Add a comment at the current position"
-msgstr ""
+msgstr "Añade un comentario en la posición actual"
 
 #. Translators: the label of an item in the application menubar
-#: bookworm/annotation/annotation_gui.py:120
+#: bookworm/annotation/annotation_gui.py:123
 msgid "&Highlight Selection\tCtrl-H"
-msgstr ""
+msgstr "Resaltar &Selección\tCtrl-H"
 
 #. Translators: the help text of an item in the application menubar
-#: bookworm/annotation/annotation_gui.py:122
+#: bookworm/annotation/annotation_gui.py:125
 msgid "Highlight selected text and save it."
-msgstr ""
+msgstr "Resalta un texto seleccionado y lo guarda."
 
 #. Translators: the label of an item in the application menubar
-#: bookworm/annotation/annotation_gui.py:127
+#: bookworm/annotation/annotation_gui.py:130
 msgid "Saved &Bookmarks..."
-msgstr ""
+msgstr "Marcas &Guardadas..."
 
 #. Translators: the help text of an item in the application menubar
-#: bookworm/annotation/annotation_gui.py:129
+#: bookworm/annotation/annotation_gui.py:132
 msgid "View added bookmarks"
-msgstr "Muestra los marcadores añadidos."
+msgstr "Ver marcas añadidas"
 
 #. Translators: the label of an item in the application menubar
-#: bookworm/annotation/annotation_gui.py:134
+#: bookworm/annotation/annotation_gui.py:137
 msgid "Saved Co&mments..."
-msgstr ""
+msgstr "Comentarios G&uardados..."
 
 #. Translators: the help text of an item in the application menubar
-#: bookworm/annotation/annotation_gui.py:136
+#: bookworm/annotation/annotation_gui.py:139
 msgid "View, edit, and remove comments."
-msgstr ""
+msgstr "Ver, editar y eliminar comentarios."
 
 #. Translators: the label of an item in the application menubar
-#: bookworm/annotation/annotation_gui.py:141
+#: bookworm/annotation/annotation_gui.py:144
 msgid "Saved &Highlights..."
-msgstr ""
+msgstr "Resal&tados Guardados..."
 
 #. Translators: the help text of an item in the application menubar
-#: bookworm/annotation/annotation_gui.py:143
+#: bookworm/annotation/annotation_gui.py:146
 msgid "View saved highlights."
-msgstr ""
+msgstr "Ver resaltados guardados."
 
-#. Translators: the label of an item in the application menubar
-#: bookworm/annotation/annotation_gui.py:147
-msgid "&Annotations"
-msgstr "&Anotaciones"
+#: bookworm/annotation/annotation_gui.py:184
+msgid "Bookmark removed"
+msgstr "Marca eliminada"
 
 #. Translators: spoken message
-#: bookworm/annotation/annotation_gui.py:185
+#: bookworm/annotation/annotation_gui.py:187
 msgid "Bookmark Added"
-msgstr ""
+msgstr "Marca Añadida"
 
 #. Translators: title of a dialog
-#: bookworm/annotation/annotation_gui.py:194
+#: bookworm/annotation/annotation_gui.py:196
 msgid "Add Named Bookmark"
-msgstr ""
+msgstr "Añadir Marca con Nombre"
 
 #. Translators: label of a text entry
-#: bookworm/annotation/annotation_gui.py:196
+#: bookworm/annotation/annotation_gui.py:198
 msgid "Bookmark name:"
-msgstr ""
+msgstr "Nombre de marca:"
 
 #. Translators: the title of a dialog to add a comment
-#: bookworm/annotation/annotation_gui.py:206
+#: bookworm/annotation/annotation_gui.py:208
 msgid "New Comment"
-msgstr ""
+msgstr "Nuevo Comentario"
 
 #. Translators: the label of an edit field to enter a comment
-#: bookworm/annotation/annotation_gui.py:208
+#: bookworm/annotation/annotation_gui.py:210
 msgid "Comment:"
-msgstr ""
+msgstr "Comentario:"
 
 #. Translators: title of a dialog
-#: bookworm/annotation/annotation_gui.py:221
+#: bookworm/annotation/annotation_gui.py:223
 msgid "Tag Comment"
-msgstr ""
+msgstr "Etiqeta de Comentario"
 
 #. Translators: label of a text entry
-#: bookworm/annotation/annotation_gui.py:223
-#: bookworm/annotation/annotation_gui.py:270
+#: bookworm/annotation/annotation_gui.py:225
+#: bookworm/annotation/annotation_gui.py:272
 msgid "Tags:"
-msgstr ""
+msgstr "Etiquetas:"
 
-#: bookworm/annotation/annotation_gui.py:235
+#: bookworm/annotation/annotation_gui.py:237
 msgid "No selection"
-msgstr ""
+msgstr "Sin selección"
 
 #. Translators: spoken message
-#: bookworm/annotation/annotation_gui.py:243
+#: bookworm/annotation/annotation_gui.py:245
 msgid "Highlight removed"
-msgstr ""
+msgstr "Resaltado eliminado"
 
 #. Translators: spoken message
-#: bookworm/annotation/annotation_gui.py:246
+#: bookworm/annotation/annotation_gui.py:248
 msgid "Already highlighted"
-msgstr ""
+msgstr "Ya resaltado"
 
 #. Translators: spoken message
-#: bookworm/annotation/annotation_gui.py:253
-#: bookworm/annotation/annotation_gui.py:259
+#: bookworm/annotation/annotation_gui.py:255
+#: bookworm/annotation/annotation_gui.py:261
 msgid "Highlight extended"
-msgstr ""
+msgstr "Resaltado extendido"
 
 #. Translators: spoken message
+#: bookworm/annotation/annotation_gui.py:264
+msgid "Selection highlighted"
+msgstr "Selección resaltada"
+
 #. Translators: title of a dialog
-#: bookworm/annotation/annotation_gui.py:268
+#: bookworm/annotation/annotation_gui.py:270
 msgid "Tag Highlight"
-msgstr ""
+msgstr "Etiqueta Resaltada"
 
 #. Translators: the title of a dialog to view bookmarks
-#: bookworm/annotation/annotation_gui.py:283
+#: bookworm/annotation/annotation_gui.py:285
 msgid "Bookmarks | {book}"
-msgstr "Marcadores | {book}"
+msgstr "Marcas | {book}"
 
-#: bookworm/annotation/annotation_gui.py:293
+#: bookworm/annotation/annotation_gui.py:295
 msgid "Comments"
-msgstr ""
+msgstr "Comentarios"
 
-#: bookworm/annotation/annotation_gui.py:306
+#: bookworm/annotation/annotation_gui.py:308
 msgid "Highlights"
-msgstr ""
+msgstr "Resaltados"
 
 #. Translators: written to output document when exporting a comment/highlight
 #. Translators: a name of a file format
 #. Translators: file type in a save as dialog
-#: bookworm/annotation/exporters/core_renderers.py:13
-#: bookworm/gui/book_viewer/menubar.py:225 bookworm/ocr/ocr_menu.py:238
+#: bookworm/annotation/exporters/core_renderers.py:15
+#: bookworm/gui/book_viewer/menubar.py:257 bookworm/ocr/ocr_menu.py:287
 msgid "Plain Text"
-msgstr "Texto plano"
+msgstr "Texto Plano"
 
-#: bookworm/annotation/exporters/core_renderers.py:25
-#: bookworm/annotation/exporters/core_renderers.py:88
+#: bookworm/annotation/exporters/core_renderers.py:27
+#: bookworm/annotation/exporters/core_renderers.py:90
 msgid "Section: {section_title}"
-msgstr ""
+msgstr "Sección: {section_title}"
 
 #. Translators: written to output document when exporting files
-#: bookworm/annotation/exporters/core_renderers.py:30
+#: bookworm/annotation/exporters/core_renderers.py:32
 msgid "Tagged: {tag}"
-msgstr ""
+msgstr "Etiquetado: {tag}"
 
 #. Translators: written to the end of the plain-text file when exporting
 #. comments or highlights
-#: bookworm/annotation/exporters/core_renderers.py:40
+#: bookworm/annotation/exporters/core_renderers.py:42
 msgid "End of File"
-msgstr ""
+msgstr "Fin de Fichero"
 
-#: bookworm/annotation/exporters/core_renderers.py:50
-#: bookworm/annotation/exporters/core_renderers.py:111
-#, fuzzy
+#: bookworm/annotation/exporters/core_renderers.py:52
+#: bookworm/annotation/exporters/core_renderers.py:113
 msgid "Page {number}"
-msgstr "Decir número de página"
+msgstr "Página {number}"
 
 #. Translators: the name of a document file format
-#: bookworm/annotation/exporters/core_renderers.py:72
+#: bookworm/annotation/exporters/core_renderers.py:74
 msgid "Markdown"
 msgstr "Markdown"
 
-#: bookworm/annotation/exporters/core_renderers.py:92
+#: bookworm/annotation/exporters/core_renderers.py:94
 msgid "Tagged: {tags}"
-msgstr ""
+msgstr "Etiquetadas: {tags}"
 
 #. Translators: written to output document when exporting a comment/highlight
-#: bookworm/annotation/exporters/core_renderers.py:124
-#, fuzzy
+#: bookworm/annotation/exporters/core_renderers.py:126
 msgid "Tagged"
-msgstr "Página"
+msgstr "Etiquetado"
 
 #. Translators: the name of a document file format
-#: bookworm/annotation/exporters/core_renderers.py:135
+#: bookworm/annotation/exporters/core_renderers.py:137
 msgid "HTML"
 msgstr "HTML"
 
-#: bookworm/annotation/exporters/core_renderers.py:154
-#, fuzzy
+#: bookworm/annotation/exporters/core_renderers.py:156
 msgid "Exported Annotations"
-msgstr "&Anotaciones"
+msgstr "Anotaciones Exportadas"
 
 #. Translators: label of a button to copy the annotation to the clipboard
 #. used when exporting annotations to HTML
-#: bookworm/annotation/exporters/core_renderers.py:184
+#: bookworm/annotation/exporters/core_renderers.py:186
 msgid "Copy to clipboard"
+msgstr "Copiar al portapapeles"
+
+#. Translators: the label of a page in the settings dialog
+#: bookworm/bookshelf/__init__.py:56
+msgid "Bookshelf"
+msgstr "Estantería"
+
+#. Translators: the label of an item in the application menubar
+#. Translators: the label of the bookshelf sub menu found in the file menu of
+#. the application
+#: bookworm/bookshelf/__init__.py:66
+msgid "Boo&kshelf"
+msgstr "&Estantería"
+
+#. Translators: the label of a group of controls in the bookshelf page in the
+#. preferences dialog
+#. Translators: the name of a book shelf type.
+#. This bookshelf type is stored in a local database
+#: bookworm/bookshelf/local_bookshelf/__init__.py:67
+#: bookworm/bookshelf/viewer_integration.py:36
+msgid "Local Bookshelf"
+msgstr "Estantería Local"
+
+#. Translators: the label of a checkbox
+#: bookworm/bookshelf/viewer_integration.py:41
+msgid "Automatically add opened books to the local bookshelf"
+msgstr "Añadir automáticamente libros abiertos a la estantería local"
+
+#. Translators: the label of an item in the application menubar
+#: bookworm/bookshelf/viewer_integration.py:54
+msgid "&Open Bookshelf"
+msgstr "&Abrir Estantería"
+
+#. Translators: the help text of an item in the application menubar
+#: bookworm/bookshelf/viewer_integration.py:56
+msgid "Open your bookshelf"
+msgstr "Abre tu estantería"
+
+#. Translators: the label of an item in the application menubar
+#: bookworm/bookshelf/viewer_integration.py:61
+msgid "&Add to local bookshelf..."
+msgstr "&Añadir a estantería Local..."
+
+#. Translators: the help text of an item in the application menubar
+#: bookworm/bookshelf/viewer_integration.py:63
+msgid "Add the current book to the local bookshelf"
+msgstr "Añade el libro actual a la estantería local"
+
+#. Translators: content of a message indicating failure to add the current
+#. document to the bookshelf
+#: bookworm/bookshelf/viewer_integration.py:93
+msgid ""
+"You can not add this document to Bookshelf.\n"
+"The document should exist locally in your computer."
 msgstr ""
+"No puedes añadir este documento a la Estantería.\n"
+"El documento debería existir localmente en tu ordenador."
+
+#. Translators: title of a message indicating failure to add the current
+#. document to the bookshelf
+#: bookworm/bookshelf/viewer_integration.py:97
+msgid "Can not add document"
+msgstr "No se puede añadir el documento"
+
+#. Translators: title of a dialog to select reading list and collections for a
+#. document when adding it to the bookshelf
+#: bookworm/bookshelf/viewer_integration.py:104
+msgid "Reading list and collections"
+msgstr "Lista de lectura y colecciones"
+
+#: bookworm/bookshelf/window.py:56
+msgid "{name} ({count})"
+msgstr "{name} ({count})"
+
+#. Translators: label of a text box to filter documents in bookshelf
+#: bookworm/bookshelf/window.py:79
+msgid "Filter documents..."
+msgstr "Filtrar documentos..."
+
+#. Translators: label of the bookshelf document list. This label is shown when
+#. the documents are being loaded from the database
+#: bookworm/bookshelf/window.py:85
+msgid "Loading items"
+msgstr "Cargando elementos"
+
+#. Translators: content of a message shown when the bookshelf fails to load and
+#. show documents
+#: bookworm/bookshelf/window.py:195
+msgid ""
+"Failed to retrieve documents.\n"
+"Please try again."
+msgstr ""
+"Error al recuperar documentos.\n"
+"Por favor inténtalo de nuevo."
+
+#. Translators: title of a message indicating an error
+#. Translators: title of a message shown when importing documents to the
+#. bookshelf has failed
+#. Translators: title  of a message shown when importing documents from a
+#. folder to the bookshelf has failed
+#. Translators: title of a message shown when searching bookshelf has failed
+#. Translators: spoken message
+#. Translators: title of a list control colum showing errors encountered when
+#. bundling documents
+#. Translators: title of a message box
+#. Translators: title of a messagebox
+#. Translators: the title of a message telling the user that an error has
+#. occurred
+#: bookworm/bookshelf/local_bookshelf/__init__.py:290
+#: bookworm/bookshelf/local_bookshelf/__init__.py:336
+#: bookworm/bookshelf/local_bookshelf/__init__.py:382
+#: bookworm/bookshelf/local_bookshelf/dialogs.py:229
+#: bookworm/bookshelf/window.py:197 bookworm/gui/settings.py:623
+#: bookworm/ocr/ocr_dialogs.py:215 bookworm/ocr/ocr_dialogs.py:625
+#: bookworm/platforms/win32/pandoc_download.py:63
+#: bookworm/platforms/win32/tesseract_download.py:96
+#: bookworm/text_to_speech/tts_gui.py:429 bookworm/webservices/wikiworm.py:170
+msgid "Error"
+msgstr "Error"
+
+#. Translators: label of an item in the context menu of a document in the
+#. bookshelf
+#. Translators: the label of the close button in a dialog
+#: bookworm/bookshelf/window.py:237
+#: bookworm/gui/book_viewer/core_dialogs.py:397
+msgid "&Open"
+msgstr "&Abrir"
+
+#. Translators: label of an item in the context menu of a document in the
+#. bookshelf
+#: bookworm/bookshelf/window.py:242
+msgid "Open in &system viewer"
+msgstr "Abrir en el visualizador del &sistema"
+
+#. Translators: label of an item in the context menu of a document in the
+#. bookshelf
+#: bookworm/bookshelf/window.py:247
+msgid "Edit &title"
+msgstr "Editar &título"
+
+#. Translators: spoken message when activating a document
+#. Translators: spoken message when no matching documents were found when
+#. filtering the document list
+#: bookworm/bookshelf/window.py:300
+msgid "No matching documents"
+msgstr "No hay documentos coincidentes"
+
+#. Translators: message shown when loading documents in the bookshelf
+#: bookworm/bookshelf/window.py:354 bookworm/bookshelf/window.py:366
+msgid "Retrieving items..."
+msgstr "Recuperando elementos..."
+
+#. Translators: label of an item in the context menu of a document in the
+#. bookshelf
+#: bookworm/bookshelf/window.py:391
+msgid "Document &info..."
+msgstr "&Información de documento..."
+
+#. Translators: label of the combo box showing a list of bookshelf providers.
+#. Currently, only the Local Bookshelf provider is implemented. In the future,
+#. other providers may be added, such as Bookshare and Pocket.
+#: bookworm/bookshelf/window.py:422
+msgid "Provider"
+msgstr "Proveedor"
+
+#. Translators: label of the bookshelf tree that shows reading lists and
+#. collections and other categories
+#. Translators: label of the settings categories list box
+#: bookworm/bookshelf/window.py:429 bookworm/bookshelf/window.py:435
+#: bookworm/gui/settings.py:666
+msgid "Categories"
+msgstr "Categorías"
+
+#. Translators: title of Bookshelf window
+#: bookworm/bookshelf/window.py:472
+msgid "Bookworm Bookshelf: {name}"
+msgstr "Estantería de Bookworm: {name}"
+
+#. Translators: label of a menu item to exit the application
+#: bookworm/bookshelf/window.py:496
+msgid "&Exit"
+msgstr "&Salir"
+
+#. Translators: lable of the file menu in the menu bar
+#. Translators: the label of an item in the application menubar
+#: bookworm/bookshelf/window.py:499 bookworm/gui/book_viewer/menubar.py:889
+msgid "&File"
+msgstr "&Archivo"
+
+#. Translators: the label of a menu item to remove a bookshelf reading list or
+#. collection
+#: bookworm/bookshelf/local_bookshelf/__init__.py:76
+msgid "Remove..."
+msgstr "Eliminar..."
+
+#. Translators: the label of a menu item to change the name of a bookshelf
+#. reading list or collection
+#: bookworm/bookshelf/local_bookshelf/__init__.py:81
+msgid "Edit name..."
+msgstr "Editar nombre..."
+
+#. Translators: the label of a menu item to remove all documents under a
+#. specific bookshelf reading list or collection
+#: bookworm/bookshelf/local_bookshelf/__init__.py:86
+msgid "Clear documents..."
+msgstr "Borrar documentos..."
+
+#. Translators: the name of a category in the bookshelf for recently added
+#. documents
+#: bookworm/bookshelf/local_bookshelf/__init__.py:110
+msgid "Recently Added"
+msgstr "Añadidos Recientemente"
+
+#. Translators: the name of a category in the bookshelf for documents currently
+#. being read by the user
+#: bookworm/bookshelf/local_bookshelf/__init__.py:117
+msgid "Currently Reading"
+msgstr "Lectura Actual"
+
+#. Translators: the name of a category in the bookshelf for documents the user
+#. wants to read
+#: bookworm/bookshelf/local_bookshelf/__init__.py:126
+msgid "Want to Read"
+msgstr "Quiero Leer"
+
+#. Translators: the name of a category in the bookshelf for documents favored
+#. by the user
+#: bookworm/bookshelf/local_bookshelf/__init__.py:135
+msgid "Favorites"
+msgstr "Favoritos"
+
+#. Translators: the name of a category in the bookshelf which contains the
+#. user's reading lists
+#: bookworm/bookshelf/local_bookshelf/__init__.py:145
+msgid "Reading Lists"
+msgstr "Listas de Lectura"
+
+#. Translators: the name of a category in the bookshelf which contains the
+#. user's collections
+#. Translators: label of a text box for entering a document's collections
+#: bookworm/bookshelf/local_bookshelf/__init__.py:150
+#: bookworm/bookshelf/local_bookshelf/dialogs.py:51
+msgid "Collections"
+msgstr "Colecciones"
+
+#. Translators: the name of a reading list in the bookshelf which contains
+#. documents that do not have any category assigned to them
+#. Translators: the label of a page in the settings dialog
+#: bookworm/bookshelf/local_bookshelf/__init__.py:158
+#: bookworm/gui/settings.py:634
+msgid "General"
+msgstr "General"
+
+#. Translators: the label of a menu item in the bookshelf to add a new reading
+#. list or collection
+#: bookworm/bookshelf/local_bookshelf/__init__.py:167
+msgid "Add New..."
+msgstr "Añadir Nuevo..."
+
+#. Translators: the name of a category in the bookshelf that lists the authors
+#. of the documents stored in the bookshelf
+#: bookworm/bookshelf/local_bookshelf/__init__.py:186
+#: bookworm/gui/book_viewer/core_dialogs.py:362
+msgid "Authors"
+msgstr "Autores"
+
+#. Translators: the label of a menu item in the bookshelf file menu to import
+#. documents to the bookshelf
+#: bookworm/bookshelf/local_bookshelf/__init__.py:197
+msgid "Import Documents...\tCtrl+O"
+msgstr "Importar Documentos...\tCtrl+O"
+
+#. Translators: the label of a menu item in the bookshelf file menu to import
+#. an entire folder to the bookshelf
+#: bookworm/bookshelf/local_bookshelf/__init__.py:202
+msgid "Import documents from folder..."
+msgstr "Importar documentos desde la Carpeta..."
+
+#. Translators: the label of a menu item in the bookshelf file menu to search
+#. documents contained in the bookshelf
+#: bookworm/bookshelf/local_bookshelf/__init__.py:206
+msgid "Search Bookshelf..."
+msgstr "Buscar en Estantería..."
+
+#. Translators: the label of a menu item in the bookshelf file menu to copy the
+#. files added to the bookshelf to a private folder that blongs to Bookworm.
+#. This is important to make the bookshelf works with  portable copies, or if
+#. the user wants to move or rename added documents
+#: bookworm/bookshelf/local_bookshelf/__init__.py:209
+msgid "Bundle Documents..."
+msgstr "Documentos Empaquetados..."
+
+#. Translators: the label of a menu item in the bookshelf file menu to clear
+#. documents that no longer exist in the file system
+#: bookworm/bookshelf/local_bookshelf/__init__.py:212
+msgid "Clear invalid documents..."
+msgstr "Borrar documentos inválidos..."
+
+#. Translators: the title of a file dialog to browse to a document
+#: bookworm/bookshelf/local_bookshelf/__init__.py:224
+msgid "Import Documents To Bookshelf"
+msgstr "Importar Documentos a la Estantería"
+
+#. Translators: the title of a dialog to edit the document's reading list or
+#. collection
+#. Translators: title of a dialog to change the reading list or collection for
+#. a document
+#: bookworm/bookshelf/local_bookshelf/__init__.py:240
+#: bookworm/bookshelf/local_bookshelf/__init__.py:640
+msgid "Edit reading list/collections"
+msgstr "Editar lista de lectura y colecciones"
+
+#. Translators: a message shown when Bookworm is importing documents to the
+#. bookshelf
+#: bookworm/bookshelf/local_bookshelf/__init__.py:257
+msgid "Importing document..."
+msgstr "Importando documento..."
+
+#. Translators: a message shown when Bookworm is importing documents to the
+#. bookshelf
+#: bookworm/bookshelf/local_bookshelf/__init__.py:260
+msgid "Importing documents..."
+msgstr "Importando documentos..."
+
+#. Translators: content of a message shown when importing documents to the
+#. bookshelf has failed
+#: bookworm/bookshelf/local_bookshelf/__init__.py:288
+msgid "Failed to import document. Please try again."
+msgstr "Error al importar el documento. Por favor inténtalo de nuevo."
+
+#. Translators: title of a dialog to import an entire folder to the bookshelf
+#: bookworm/bookshelf/local_bookshelf/__init__.py:301
+msgid "Import Documents From Folder"
+msgstr "Importar Documentos desde la carpeta"
+
+#. Translators: a message shown when importing an entire folder to the
+#. bookshelf
+#: bookworm/bookshelf/local_bookshelf/__init__.py:315
+msgid "Importing documents from folder. Please wait..."
+msgstr "Importando documentos desde la carpeta. Por favor espera..."
+
+#. Translators: content of a message shown when importing documents from a
+#. folder to the bookshelf is successful
+#: bookworm/bookshelf/local_bookshelf/__init__.py:324
+msgid "Documents imported from folder."
+msgstr "Documentos importados desde la carpeta."
+
+#. Translators: title of a message shown when importing documents from a folder
+#. to the bookshelf is successful
+#: bookworm/bookshelf/local_bookshelf/__init__.py:326
+msgid "Operation Completed"
+msgstr "Operación Completada"
+
+#. Translators: content of a message shown when importing documents from a
+#. folder to the bookshelf has failed
+#: bookworm/bookshelf/local_bookshelf/__init__.py:334
+msgid "Failed to import documents from folder."
+msgstr "Error al importar documentos desde la carpeta."
+
+#. Translators: title of a dialog to search bookshelf
+#: bookworm/bookshelf/local_bookshelf/__init__.py:344
+msgid "Search Bookshelf"
+msgstr "Buscar en la Estantería"
+
+#. Translators: a message shown while searching bookshelf
+#: bookworm/bookshelf/local_bookshelf/__init__.py:357
+msgid "Searching bookshelf..."
+msgstr "Buscando en la estantería..."
+
+#. Translators: content of a message shown when searching bookshelf has failed
+#: bookworm/bookshelf/local_bookshelf/__init__.py:380
+msgid "Failed to search bookshelf,"
+msgstr "Error buscando en la Estantería,"
+
+#. Translators: title of a dialog that shows bookshelf search results. It
+#. searches documents by title and content, hence full-text
+#: bookworm/bookshelf/local_bookshelf/__init__.py:397
+msgid "Full Text Search Results"
+msgstr "Resultados de la Búsqueda de Texto Completa"
+
+#. Translators: content of a message to confirm the bundling of documents added
+#. to bookshelf
+#: bookworm/bookshelf/local_bookshelf/__init__.py:407
+msgid ""
+"This will create copies of all of the documents you have added to your Local "
+"Bookshelf.\n"
+"After this operation, you can open documents stored in your bookshelf, even "
+"if you have deleted or moved the original documents.\n"
+"\n"
+"Please note that this action will create duplicate copies of all of your "
+"added documents."
+msgstr ""
+"Esto creará copias de todos los documentos que hayas añadido a tu estantería "
+"local.\n"
+"Después de esta operación, podrás abrir los documentos almacenados en tu "
+"Estantería, incluso si has eliminado o movido los documentos originales.\n"
+"\n"
+"Ten en cuenta que esta acción creará copias duplicadas de todos los "
+"documentos que hayas añadido."
+
+#. Translators: title of a message to confirm the bundling of documents added
+#. to bookshelf
+#: bookworm/bookshelf/local_bookshelf/__init__.py:411
+msgid "Bundle Documents?"
+msgstr "¿Empaquetar Documentos?"
+
+#. Translators: a message shown when bundling documents added to bookshelf
+#: bookworm/bookshelf/local_bookshelf/__init__.py:419
+msgid "Bundling documents. Please wait..."
+msgstr "Empaquetando documentos. Por favor espera..."
+
+#. Translators: content of a message when bundling of documents is successful
+#: bookworm/bookshelf/local_bookshelf/__init__.py:448
+msgid "Bundled {num_documents} files."
+msgstr "Empaquetados {num_documents} ficheros."
+
+#. Translators: title of a message when bundling of documents is successful
+#: bookworm/bookshelf/local_bookshelf/__init__.py:450
+msgid "Done"
+msgstr "Hecho"
+
+#. Translators: title of a dialog that shows titles and paths of documents
+#. which have not been bundled successfully
+#: bookworm/bookshelf/local_bookshelf/__init__.py:458
+msgid "Bundle Results: {num_succesfull} successfull, {num_faild} faild"
+msgstr ""
+"Resultados de Empaquetado: {num_succesfull} satisfactorios, {num_faild} "
+"fallaron"
+
+#. Translators: content of a message to confirm the clearing of documents
+#. which have been added to bookshelf, but they have been moved, renamed, or
+#. deleted
+#: bookworm/bookshelf/local_bookshelf/__init__.py:470
+msgid ""
+"This action will clear invalid documents from your bookshelf.\n"
+"Invalid documents are the documents which no longer exist on your computer."
+msgstr ""
+"Esta acción borrará los documentos inválidos de tu estantería.\n"
+"Los documentos inválidos son los documentos que ya no existan en tu "
+"ordenador."
+
+#. Translators: title of a message to confirm the clearing of documents
+#. which have been added to bookshelf, but they have been moved, renamed, or
+#. deleted
+#: bookworm/bookshelf/local_bookshelf/__init__.py:475
+msgid "Clear Invalid Documents?"
+msgstr "¿Borrar Documentos Inválidos?"
+
+#. Translators: label of a text box to change the name of a reading list or
+#. collection
+#: bookworm/bookshelf/local_bookshelf/__init__.py:490
+msgid "New name:"
+msgstr "Nombre nuevo:"
+
+#. Translators: title of a dialog to change the name of a reading list or
+#. collection
+#: bookworm/bookshelf/local_bookshelf/__init__.py:492
+msgid "Edit Name"
+msgstr "Editar Nombre"
+
+#. Translators: content of a message when changing the name of a reading list
+#. or collection was not successful
+#: bookworm/bookshelf/local_bookshelf/__init__.py:502
+msgid ""
+"The given name {name} already exists.\n"
+"Please choose another name."
+msgstr ""
+"El nombre {name} dado ya existe.\n"
+"Por favor elige otro nombre."
+
+#. Translators: title of a message when changing the name of a reading list or
+#. collection was not successful
+#: bookworm/bookshelf/local_bookshelf/__init__.py:506
+msgid "Duplicate name"
+msgstr "Nombre duplicado"
+
+#. Translators: content of a message to confirm the removal of a reading list
+#. or collection
+#: bookworm/bookshelf/local_bookshelf/__init__.py:516
+msgid ""
+"Are you sure you want to remove {name}?\n"
+"This will not remove document classified under {name}."
+msgstr ""
+"¿Estás seguro de que quieres eliminar {name}?\n"
+"Esto no eliminará documentos clasificados bajo {name}."
+
+#. Translators: title of a message to confirm the removal of a reading list or
+#. collection
+#. Translators: title of a message box
+#. Translators: title of a messagebox
+#: bookworm/bookshelf/local_bookshelf/__init__.py:520
+#: bookworm/gui/components.py:610 bookworm/ocr/ocr_dialogs.py:541
+#: bookworm/ocr/ocr_dialogs.py:583
+msgid "Confirm"
+msgstr "Confirmar"
+
+#. Translators: content of a message to confirm the removal of all documents
+#. classified under a specific reading list or collection
+#: bookworm/bookshelf/local_bookshelf/__init__.py:531
+msgid ""
+"Are you sure you want to clear all documents classified under {name}?\n"
+"This will remove those documents from your bookshelf."
+msgstr ""
+"¿Estás seguro de que quieres borrar todos los documentos clasificados bajo "
+"{name}?\n"
+"Esto borrará esos documentos de tu estantería."
+
+#. Translators: title of a message to confirm the removal of all documents
+#. classified under a specific reading list or collection
+#: bookworm/bookshelf/local_bookshelf/__init__.py:535
+msgid "Clear All Documents"
+msgstr "Borrar todos los Documentos"
+
+#. Translators: label of a text box for the name of a new reading list or
+#. collection
+#: bookworm/bookshelf/local_bookshelf/__init__.py:548
+msgid "Enter name:"
+msgstr "Introducir nombre:"
+
+#. Translators: title of a dialog  for adding a new reading list or collection
+#: bookworm/bookshelf/local_bookshelf/__init__.py:550
+msgid "Add New"
+msgstr "Añadir Nuevo"
+
+#. Translators: label of an item in the context menu of a document in the
+#. bookshelf
+#: bookworm/bookshelf/local_bookshelf/__init__.py:575
+msgid "&Edit reading list / collections..."
+msgstr "&Editar lista de lectura y colecciones..."
+
+#. Translators: label of an item in the context menu of a document in the
+#. bookshelf
+#: bookworm/bookshelf/local_bookshelf/__init__.py:580
+msgid "Remove from &currently reading"
+msgstr "Eliminar de lectura &actual"
+
+#. Translators: label of an item in the context menu of a document in the
+#. bookshelf
+#: bookworm/bookshelf/local_bookshelf/__init__.py:582
+msgid "Add to &currently reading"
+msgstr "Añadir a lectura &actual"
+
+#. Translators: label of an item in the context menu of a document in the
+#. bookshelf
+#: bookworm/bookshelf/local_bookshelf/__init__.py:587
+msgid "Remove from &want to read"
+msgstr "Eliminar de &quiero leer"
+
+#. Translators: label of an item in the context menu of a document in the
+#. bookshelf
+#: bookworm/bookshelf/local_bookshelf/__init__.py:589
+msgid "Add to &want to read"
+msgstr "Añadir a &quiero leer"
+
+#. Translators: label of an item in the context menu of a document in the
+#. bookshelf
+#: bookworm/bookshelf/local_bookshelf/__init__.py:594
+msgid "Remove from &favorites"
+msgstr "Eliminar de &favoritos"
+
+#. Translators: label of an item in the context menu of a document in the
+#. bookshelf
+#: bookworm/bookshelf/local_bookshelf/__init__.py:596
+msgid "Add to &favorites"
+msgstr "Añadir a &favoritos"
+
+#. Translators: label of an item in the context menu of a document in the
+#. bookshelf
+#: bookworm/bookshelf/local_bookshelf/__init__.py:601
+msgid "&Remove from bookshelf"
+msgstr "&Eliminar de estantería"
+
+#. Translators: content of a message to confirm the removal of this document
+#. from bookshelf
+#: bookworm/bookshelf/local_bookshelf/__init__.py:667
+msgid ""
+"Are you sure you want to remove this document from your bookshelf?\n"
+"Title: {title}\n"
+"This will remove the document from all tags and categories."
+msgstr ""
+"¿Estás seguro de que quieres eliminar este documento de tu estantería?\n"
+"Título: {title}\n"
+"Esto eliminará el documento de todas las etiquetas y categorías."
+
+#. Translators: title of a message to confirm the removal of this document from
+#. bookshelf
+#: bookworm/bookshelf/local_bookshelf/__init__.py:671
+msgid "Remove From Bookshelf?"
+msgstr "¿Eliminar de tu Estantería?"
+
+#. Translators: the name of a category under the Authors category. This
+#. category shows documents for which  author info is not available
+#: bookworm/bookshelf/local_bookshelf/__init__.py:703
+msgid "Unknown Author"
+msgstr "Autor Desconocido"
+
+#. Translators: label of a combo box for choosing a document's reading list
+#. Translators: label of a button
+#: bookworm/bookshelf/local_bookshelf/dialogs.py:47
+#: bookworm/bookshelf/local_bookshelf/dialogs.py:90
+msgid "Reading List"
+msgstr "Lista de Lectura"
+
+#. Translators: label of a check box
+#: bookworm/bookshelf/local_bookshelf/dialogs.py:55
+#: bookworm/bookshelf/local_bookshelf/dialogs.py:97
+msgid "Add to full-text search index"
+msgstr "Añadir al índice de búsqueda de texto completo"
+
+#. Translators: label of an edit control for entering the path to a folder to
+#. import to the bookshelf
+#: bookworm/bookshelf/local_bookshelf/dialogs.py:84
+msgid "Select a folder:"
+msgstr "Seleccionar una carpeta:"
+
+#. Translators: label of a text box for entering a search term
+#. Translators: the label of a button in the application toolbar
+#: bookworm/bookshelf/local_bookshelf/dialogs.py:116
+#: bookworm/gui/book_viewer/__init__.py:412
+msgid "Search"
+msgstr "Búsqueda"
+
+#. Translators: title of a group of controls to select which document field to
+#. search in when searching bookshelf
+#: bookworm/bookshelf/local_bookshelf/dialogs.py:120
+msgid "Search Field"
+msgstr "Campo de Búsqueda"
+
+#. Translators: label of a check box that enables/disables searching document
+#. title when searching the bookshelf
+#. Translators: header of a column in a list control in a dialog showing a list
+#. of search results of matching document titles
+#. Translators: title of a list control colum showing the document titles  of
+#. documents not bundled due to errors when bundling documents
+#: bookworm/bookshelf/local_bookshelf/dialogs.py:124
+#: bookworm/bookshelf/local_bookshelf/dialogs.py:190
+#: bookworm/bookshelf/local_bookshelf/dialogs.py:233
+#: bookworm/gui/book_viewer/core_dialogs.py:351
+msgid "Title"
+msgstr "Título"
+
+#. Translators: label of a list showing search results of documents with title
+#. matching the given  search query
+#: bookworm/bookshelf/local_bookshelf/dialogs.py:158
+msgid "Title matches"
+msgstr "Coincidencias de título"
+
+#. Translators: the label of a tab in a tabl control in a dialog showing a list
+#. of search results in the bookshelf
+#: bookworm/bookshelf/local_bookshelf/dialogs.py:161
+msgid "Title Matches"
+msgstr "Títulos coincidentes"
+
+#. Translators: label of a list showing search results of content matching the
+#. given  search query
+#: bookworm/bookshelf/local_bookshelf/dialogs.py:168
+msgid "Content matches"
+msgstr "Coincidencias de contenido"
+
+#. Translators: the label of a tab in a tabl control in a dialog showing a list
+#. of search results in the bookshelf
+#: bookworm/bookshelf/local_bookshelf/dialogs.py:171
+msgid "Content Matches"
+msgstr "Contenidos coincidentes"
+
+#: bookworm/bookshelf/local_bookshelf/dialogs.py:187
+msgid "Snippet"
+msgstr "Recortes"
+
+#. Translators: title of a list control colum showing the file names of files
+#. not bundled due to errors when bundling documents
+#: bookworm/bookshelf/local_bookshelf/dialogs.py:231
+msgid "File Name"
+msgstr "Nombre de Archivo"
+
+#. Translators: label of a list control showing file copy errors
+#: bookworm/bookshelf/local_bookshelf/dialogs.py:236
+msgid "Errors"
+msgstr "Errores"
+
+#. Translators: label shown in a list control indicating the failure to copy
+#. the document when bundling documents
+#: bookworm/bookshelf/local_bookshelf/dialogs.py:239
+msgid "Failed to copy document"
+msgstr "Error al copiar el documento"
+
+#: bookworm/document/features.py:53
+msgid "Default reading mode"
+msgstr "Modo de lectura por defecto"
+
+#: bookworm/document/features.py:54
+msgid "Reading order"
+msgstr "Orden de lectura"
+
+#: bookworm/document/features.py:55
+msgid "Physical layout"
+msgstr "Disposición física"
+
+#: bookworm/document/features.py:56
+msgid "Paginated"
+msgstr "Paginado"
+
+#: bookworm/document/features.py:57
+msgid "Chapter by chapter"
+msgstr "Capítulo a capítulo"
+
+#: bookworm/document/features.py:58
+msgid "Clean text"
+msgstr "Borrar texto"
+
+#: bookworm/document/features.py:59
+msgid "Full text"
+msgstr "Texto completo"
 
 #. Translators: the name of a document file format
-#: bookworm/document_formats/epub_document.py:133
+#: bookworm/document/formats/archive.py:45
+msgid "Archive File"
+msgstr "Archive File"
+
+#. Translators: the name of a document file format
+#: bookworm/document/formats/epub.py:46
 msgid "Electronic Publication (EPUB)"
 msgstr "Publicación Electrónica (EPUB)"
 
-#: bookworm/document_formats/epub_document.py:199
-#, fuzzy
-msgid "Book contents"
-msgstr "Tabla de contenido"
-
 #. Translators: the name of a document file format
-#: bookworm/document_formats/fitz_document.py:169
+#: bookworm/document/formats/fb2.py:23 bookworm/document/formats/fb2.py:34
 msgid "Fiction Book (FB2)"
-msgstr ""
+msgstr "Fiction Book (FB2)"
 
 #. Translators: the name of a document file format
-#: bookworm/document_formats/fitz_document.py:195
+#: bookworm/document/formats/fitz.py:174
 msgid "XPS Document"
-msgstr ""
+msgstr "Documento XPS"
 
 #. Translators: the name of a document file format
-#: bookworm/document_formats/fitz_document.py:203
+#: bookworm/document/formats/fitz.py:181
 msgid "Comic Book Archive"
-msgstr ""
+msgstr "Archivo Comic Book"
 
 #. Translators: the name of a document file format
-#: bookworm/document_formats/html_document.py:204
+#: bookworm/document/formats/html.py:189 bookworm/document/formats/html.py:258
 msgid "HTML Document"
-msgstr ""
+msgstr "Documento HTML"
 
 #. Translators: the name of a document file format
-#: bookworm/document_formats/markdown_document.py:25
-#, fuzzy
+#: bookworm/document/formats/markdown.py:19
 msgid "Markdown File"
-msgstr "Markdown"
+msgstr "Archivo Markdown"
 
 #. Translators: the name of a document file format
-#: bookworm/document_formats/mobi_document.py:41
+#: bookworm/document/formats/mobi.py:39
 msgid "Kindle eBook"
-msgstr ""
+msgstr "Kindle eBook"
 
 #. Translators: the name of a document file format
-#: bookworm/document_formats/odf_document.py:88
+#: bookworm/document/formats/odf.py:81
 msgid "Open Document Text"
-msgstr ""
+msgstr "Texto Open Document"
 
 #. Translators: the name of a document file format
-#: bookworm/document_formats/odf_document.py:134
+#: bookworm/document/formats/odf.py:127
 msgid "Open Document Presentation"
-msgstr ""
+msgstr "Presentación de Open Document"
 
-#: bookworm/document_formats/odf_document.py:198
-#: bookworm/document_formats/powerpoint_presentation.py:161
+#: bookworm/document/formats/odf.py:190
+#: bookworm/document/formats/powerpoint.py:155
 msgid "Slide {number}"
-msgstr ""
+msgstr "Diapositiva {number}"
 
 #. Translators: the name of a document file format
-#: bookworm/document_formats/pdf_document.py:47
+#: bookworm/document/formats/pandoc.py:38
+msgid "Rich Text Document"
+msgstr "Documento de Texto Enriquecido"
+
+#. Translators: the name of a document file format
+#: bookworm/document/formats/pandoc.py:47
+msgid "Docbook Document"
+msgstr "Documento Docbook"
+
+#. Translators: the name of a document file format
+#: bookworm/document/formats/pandoc.py:56
+msgid "Jupyter notebook"
+msgstr "Jupyter notebook"
+
+#. Translators: the name of a document file format
+#: bookworm/document/formats/pandoc.py:65
+msgid "LaTeX Document"
+msgstr "Documento LaTeX"
+
+#. Translators: the name of a document file format
+#: bookworm/document/formats/pandoc.py:74
+msgid "Text2Tags Document"
+msgstr "Documento Text2Tags"
+
+#. Translators: the name of a document file format
+#: bookworm/document/formats/pandoc.py:83
+msgid "Unix manual page"
+msgstr "Página de Manual Unix"
+
+#. Translators: the name of a document file format
+#: bookworm/document/formats/pdf.py:73
 msgid "Portable Document (PDF)"
-msgstr "Documento Portable (PDF)"
+msgstr "Portable Document (PDF)"
 
 #. Translators: the name of a document file format
-#: bookworm/document_formats/plain_text_document.py:27
+#: bookworm/document/formats/plain_text.py:31
 msgid "Plain Text File"
-msgstr ""
+msgstr "Archivo de Texto Plano"
 
-#: bookworm/document_formats/powerpoint_presentation.py:91
+#: bookworm/document/formats/powerpoint.py:85
 msgid "Slide Notes"
-msgstr ""
+msgstr "Notas de Diapositiva"
 
 #. Translators: the name of a document file format
-#: bookworm/document_formats/powerpoint_presentation.py:122
+#: bookworm/document/formats/powerpoint.py:115
 msgid "PowerPoint Presentation"
-msgstr ""
+msgstr "Presentación de PowerPoint"
 
 #. Translators: the name of a document file format
-#: bookworm/document_formats/word_document.py:36
+#: bookworm/document/formats/word.py:44
 msgid "Word Document"
+msgstr "Documento de Word"
+
+#. Translators: the name of a document file format
+#: bookworm/document/formats/word.py:134
+msgid "Word 97 - 2003 Document"
+msgstr "Documento Word 97 - 2003"
+
+#: bookworm/epub_serve/__init__.py:43
+msgid "Open in &web Viewer"
+msgstr "Abrir en visualizador &web"
+
+#: bookworm/epub_serve/__init__.py:44
+msgid "Open the current EPUB book in the browser"
+msgstr "Abrir el libro EPUB actual en el navegador"
+
+#: bookworm/epub_serve/__init__.py:61
+msgid "Openning in web viewer..."
+msgstr "Abriendo en visualizador web..."
+
+#: bookworm/epub_serve/__init__.py:81
+msgid "Failed to launch web viewer"
+msgstr "Error al lanzar el visualizador web"
+
+#: bookworm/epub_serve/__init__.py:82
+msgid "An error occurred while opening the web viewer. Please try again."
 msgstr ""
+"Ocurrió un error mientras se abría el visualizador web. Por favor inténtalo "
+"de nuevo."
 
-#: bookworm/document_formats/base/features.py:45
-#, fuzzy
-msgid "Default reading mode"
-msgstr "Empieza a leer en voz alta"
+#: bookworm/epub_serve/webapp.py:148
+msgid "404 Not Found"
+msgstr "404 No Encontrado"
 
-#: bookworm/document_formats/base/features.py:46
-#, fuzzy
-msgid "Reading order"
-msgstr "Detiene la lectura en voz alta"
-
-#: bookworm/document_formats/base/features.py:47
-msgid "Physical layout"
+#: bookworm/epub_serve/webapp.py:149
+msgid ""
+"The book you are trying to access does not exist or has been closed. Please "
+"make sure you opened the book from within Bookworm. All URLs are temporary "
+"and may not work after you close the page."
 msgstr ""
+"El libro al que estás tratando de acceder no existe o se ha cerrado. Por "
+"favor asegúrate de que hayas abierto el libro desde dentro de Bookworm. "
+"Todas las URLs son temporales y pueden no funcionar después de que cierres "
+"la página."
 
-#: bookworm/document_formats/base/features.py:48
-msgid "Paginated"
+#: bookworm/epub_serve/webapp.py:188
+msgid "Failed to load content"
+msgstr "Error al cargar el contenido"
+
+#: bookworm/epub_serve/webapp.py:189
+msgid "Cannot retreive content. Probably the eBook has been closed."
 msgstr ""
+"No se pudieron recuperar los contenidos. Probablemente el libro electrónico "
+"se ha cerrado."
 
-#: bookworm/document_formats/base/features.py:49
-msgid "Chapter by chapter"
-msgstr ""
-
-#: bookworm/document_formats/base/features.py:50
-#, fuzzy
-msgid "Clean text"
-msgstr "Texto plano"
-
-#: bookworm/document_formats/base/features.py:51
-msgid "Full text"
-msgstr ""
+#. Translators: The title for the dialog used to present general messages in
+#. browse mode.
+#: bookworm/gui/browseable_message.py:46
+msgid "Message"
+msgstr "Mensaje"
 
 #. Translators: the title of a group of controls in the search dialog
-#: bookworm/gui/components.py:100
+#: bookworm/gui/components.py:104
 msgid "Search Range"
-msgstr "Rango de búsqueda"
+msgstr "Rango de Búsqueda"
 
 #. Translators: the label of a radio button in the search dialog
-#: bookworm/gui/components.py:102
+#: bookworm/gui/components.py:106
 msgid "Page Range"
-msgstr "Rango de páginas"
+msgstr "Rango de Páginas"
 
 #. Translators: the label of an edit field in the search dialog
 #. to enter the page from which the search will start
-#: bookworm/gui/components.py:108
+#: bookworm/gui/components.py:112
 msgid "From:"
-msgstr "Desde:"
+msgstr "De:"
 
 #. Translators: the label of an edit field in the search dialog
 #. to enter the page number at which the search will stop
-#: bookworm/gui/components.py:114
+#: bookworm/gui/components.py:118
 msgid "To:"
-msgstr "Hasta:"
+msgstr "Para:"
 
 #. Translators: the label of a radio button in the search dialog
-#: bookworm/gui/components.py:119
+#: bookworm/gui/components.py:123
 msgid "Specific section"
-msgstr "Sección específica"
+msgstr "Especificar sección"
 
 #. Translators: the label of a combobox in the search dialog
 #. to choose the section to which the search will be confined
-#: bookworm/gui/components.py:122
+#: bookworm/gui/components.py:126
 msgid "Select section:"
 msgstr "Seleccionar sección:"
 
 #. Translators: the label of the OK button in a dialog
-#: bookworm/gui/components.py:232 bookworm/gui/components.py:273
-#: bookworm/gui/settings.py:460
+#: bookworm/gui/components.py:277 bookworm/gui/components.py:318
+#: bookworm/gui/settings.py:690
 msgid "OK"
 msgstr "Aceptar"
 
 #. Translators: the lable of the cancel button in a dialog
 #. Translators: the label of the cancel button in a dialog
-#: bookworm/gui/components.py:235 bookworm/gui/components.py:276
-#: bookworm/gui/settings.py:463
+#: bookworm/gui/components.py:280 bookworm/gui/components.py:321
+#: bookworm/gui/settings.py:693
 msgid "Cancel"
 msgstr "Cancelar"
 
 #. Translators: content of a message to confirm the closing of a progress
 #. dialog
-#: bookworm/gui/components.py:567
+#: bookworm/gui/components.py:606
 msgid ""
 "This will cancel all the operations in progress.\n"
 "Are you sure you want to abort?"
 msgstr ""
-
-#. Translators: title of a message box
-#. Translators: title of a messagebox
-#: bookworm/gui/components.py:571 bookworm/ocr/ocr_dialogs.py:413
-#: bookworm/ocr/ocr_dialogs.py:450
-msgid "Confirm"
-msgstr ""
+"Esto cancelará todas las operaciones en progreso.\n"
+"¿Estás seguro de que quieres abortar?"
 
 #. Translators: the title of the file associations dialog
-#: bookworm/gui/settings.py:39
+#: bookworm/gui/settings.py:47
 msgid "Bookworm File Associations"
-msgstr "Asociaciones de archivo para Bookworm"
+msgstr "Asociaciones de Archivos de Bookworm"
 
-#: bookworm/gui/settings.py:51
-#, fuzzy
+#: bookworm/gui/settings.py:59
 msgid ""
-"This dialog will help you to setup file associations.\n"
+"This dialog will help you to set up file associations.\n"
 "Associating files with Bookworm means that when you click on a file in "
-"windows explorer, it will be opened in Bookworm by default "
+"Windows Explorer, it will be opened in Bookworm by default."
 msgstr ""
-"Este diálogo le ayudará a establecer asociaciones de archivo.\n"
-"Al hacerlo, significa que cuando haga clic en un archivo en el explorador"
-" de Windows, se abrirá en Bookworm por defecto"
+"Este diálogo te ayudará a configurar las asociaciones de archivos.\n"
+"Asociar archivos con Bookworm significa que cuando hagas clic sobre un "
+"fichero en el Explorador de windows, se abrirá en Bookworm por defecto "
 
-#. Translators: the main label of a button
-#: bookworm/gui/settings.py:64
+#: bookworm/gui/settings.py:71
 msgid "Associate all"
-msgstr "Asociar todo"
+msgstr "Asociar todos"
 
-#. Translators: the note of a button
-#: bookworm/gui/settings.py:66
-#, fuzzy
+#: bookworm/gui/settings.py:72
 msgid "Use Bookworm to open all supported document formats"
-msgstr "Usar Bookworm para abrir todos los ebooks soportados"
+msgstr "Utiliza Bookworm para abrir todos los formatos de documento admitidos"
 
-#. Translators: the main label of a button
-#: bookworm/gui/settings.py:74
-msgid "Associate files of type {format}"
-msgstr "Asociar archivo de tipo {format}"
-
-#. Translators: the note of a button
-#: bookworm/gui/settings.py:76
-msgid "Associate files with {ext} extension so they always open in Bookworm"
-msgstr ""
-"Asociar archivos con la extensión {ext} para ser siempre abiertos por "
-"Bokworm"
-
-#. Translators: the main label of a button
-#: bookworm/gui/settings.py:89
+#: bookworm/gui/settings.py:86
 msgid "Dissociate all supported file types"
-msgstr "Desasociar todos los formatos de archivo soportados"
+msgstr "Desasociar todos los tipos de archivos admitidos"
+
+#: bookworm/gui/settings.py:87
+msgid "Remove previously associated file types"
+msgstr "Eliminar previamente los tipos de archivos asociados"
+
+#. Translators: the main label of a button
+#: bookworm/gui/settings.py:104
+msgid "Dissociate files of type {format}"
+msgstr "Asociar archivos de tipo {format}"
 
 #. Translators: the note of a button
-#: bookworm/gui/settings.py:91
-#, fuzzy
-msgid "Remove previously associated file types"
-msgstr "No registrar tipos de archivo previamente asociados "
+#: bookworm/gui/settings.py:106
+msgid ""
+"Dissociate files with {ext} extension so they no longer open in Bookworm"
+msgstr "Asociar archivos con extensión {ext} así siempre se abren en Bookworm"
+
+#. Translators: the main label of a button
+#: bookworm/gui/settings.py:112
+msgid "Associate files of type {format}"
+msgstr "Asociar archivos de tipo {format}"
+
+#. Translators: the note of a button
+#: bookworm/gui/settings.py:114
+msgid "Associate files with {ext} extension so they always open in Bookworm"
+msgstr "Asociar archivos con extensión {ext} así siempre se abren en Bookworm"
 
 #. Translators: the text of a message indicating successful file association
-#: bookworm/gui/settings.py:108
+#: bookworm/gui/settings.py:157
 msgid "Files of type {format} have been associated with Bookworm."
-msgstr "Los archivos de tipo  {format} se han asociado con Bookworm."
+msgstr "Los archivos de tipo {format} se han asociado con Bookworm."
 
 #. Translators: the title of a message indicating successful file association
 #. Translators: the title of a message indicating successful removal of file
 #. association
-#: bookworm/gui/settings.py:112 bookworm/gui/settings.py:130
+#. Translators: title of a message box
+#: bookworm/gui/book_viewer/menubar.py:337 bookworm/gui/settings.py:161
+#: bookworm/gui/settings.py:179 bookworm/platforms/win32/pandoc_download.py:45
+#: bookworm/platforms/win32/tesseract_download.py:76
 msgid "Success"
-msgstr "Éxito"
+msgstr "Correcto"
 
 #. Translators: the text of a message indicating successful removal of file
 #. associations
-#: bookworm/gui/settings.py:121
+#: bookworm/gui/settings.py:170
 msgid "All supported file types have been set to open by default in Bookworm."
-msgstr "Todos los archivos soportados se abrirán por defecto con Bookworm."
+msgstr ""
+"Todos los tipos de archivos admitidos se han configurado para abrir por "
+"defecto en Bookworm."
 
 #. Translators: the text of a message indicating successful removal of file
 #. associations
-#: bookworm/gui/settings.py:126
+#: bookworm/gui/settings.py:175
 msgid "All registered file associations have been removed."
-msgstr "Se han removido las asociaciones de archivos registradas."
+msgstr "Se han eliminado todas las asociaciones de archivos registradas."
 
 #. Translators: the title of a group of controls in the
 #. general settings page related to the UI
-#: bookworm/gui/settings.py:210
+#: bookworm/gui/settings.py:259
 msgid "User Interface"
-msgstr "Interfaz de Usuario"
+msgstr "Interface de Usuario"
 
 #. Translators: the label of a combobox containing display languages.
-#: bookworm/gui/settings.py:212
+#: bookworm/gui/settings.py:261
 msgid "Display Language:"
-msgstr "Idioma para mostrar:"
-
-#. Translators: the label of a checkbox
-#: bookworm/gui/settings.py:219
-msgid "Speak user interface messages"
-msgstr "Verbalizar mensajes para la interfaz de usuario"
-
-#. Translators: the label of a checkbox
-#: bookworm/gui/settings.py:226 bookworm/text_to_speech/tts_gui.py:92
-msgid "Speak page number"
-msgstr "Decir número de página"
-
-#. Translators: the label of a checkbox
-#: bookworm/gui/settings.py:233
-msgid "Speak section title"
-msgstr ""
-
-#. Translators: the label of a checkbox
-#: bookworm/gui/settings.py:240
-msgid "Play pagination sound"
-msgstr "Reproducir sonido para el cambio de página"
-
-#. Translators: the label of a checkbox
-#: bookworm/gui/settings.py:247
-msgid "Include page label in page title"
-msgstr ""
-
-#. Translators: the label of a checkbox
-#: bookworm/gui/settings.py:254
-msgid "Use file name instead of book title"
-msgstr "Usar nombre de archivo en lugar del título del libro"
+msgstr "Idioma de Pantalla:"
 
 #. Translators: the title of a group of controls shown in the
-#. general settings page related to miscellaneous settings
-#: bookworm/gui/settings.py:259
-msgid "Miscellaneous"
-msgstr "Misceláneo"
-
-#. Translators: the label of a checkbox
-#: bookworm/gui/settings.py:264
-msgid "Open recently opened books from the last position"
-msgstr "Abrir libros recién abiertos en la última posición"
+#. general settings page related to spoken feedback
+#: bookworm/gui/settings.py:266
+msgid "Spoken feedback"
+msgstr "Verbalización de retroalimentación"
 
 #. Translators: the label of a checkbox
 #: bookworm/gui/settings.py:271
+msgid "Speak user interface messages"
+msgstr "Verbalizar los mensajes de la interface de Usuario"
+
+#. Translators: the title of a group of controls shown in the
+#. general settings page related to miscellaneous settings
+#: bookworm/gui/settings.py:276
+msgid "Miscellaneous"
+msgstr "Miscelánea"
+
+#. Translators: the label of a checkbox
+#: bookworm/gui/settings.py:281
+msgid "Play pagination sound"
+msgstr "Reproducir sonidos de paginación"
+
+#. Translators: the label of a checkbox
+#: bookworm/gui/settings.py:288
+msgid "Include page label in page title"
+msgstr "Incluir etiquetas de página en títulos de página"
+
+#. Translators: the label of a checkbox
+#: bookworm/gui/settings.py:295
+msgid "Use file name instead of book title"
+msgstr "Utilizar nombres de archivo en lugar de títulos de libro"
+
+#. Translators: the label of a checkbox
+#: bookworm/gui/settings.py:302
+msgid "Show reading progress percentage"
+msgstr "Mostrar el progreso de lectura en porcentaje"
+
+#. Translators: the label of a checkbox
+#: bookworm/gui/settings.py:309
+msgid "Open recently opened books from the last position"
+msgstr "Abrir libros más recientes desde la última posición"
+
+#. Translators: the label of a checkbox to enable continuous reading
+#: bookworm/gui/settings.py:316
+msgid ""
+"Try to support the screen reader's continuous reading mode by automatically "
+"turning pages (may not work in some cases)"
+msgstr ""
+"Trata de admitir el modo de lectura continua del lector de pantalla pasando "
+"las páginas automáticamente (puede que no funcione en algunos casos)."
+
+#. Translators: the label of a checkbox
+#: bookworm/gui/settings.py:325
 msgid "Automatically check for updates"
-msgstr "Buscar actualizaciones automáticamente"
+msgstr "Comprobar actualizaciones automáticamente"
 
 #. Translators: the title of a group of controls shown in the
 #. general settings page related to file associations
-#: bookworm/gui/settings.py:277
+#: bookworm/gui/settings.py:331
 msgid "File Associations"
-msgstr "Asociaciones de archivo"
+msgstr "Asociaciones de Archivos"
 
 #. Translators: the label of a button
-#: bookworm/gui/settings.py:282
+#: bookworm/gui/settings.py:336
 msgid "Manage File &Associations"
-msgstr "Gestionar asociaciones de archivo"
+msgstr "Administrar &Asociaciones de Archivos"
 
 #. Translators: the content of a message asking the user to restart
-#: bookworm/gui/settings.py:302
+#: bookworm/gui/settings.py:366
 msgid ""
 "You have changed the display language of Bookworm.\n"
-"For this setting to fully take effect, you need to restart the "
-"application.\n"
+"For this setting to fully take effect, you need to restart the application.\n"
 "Would you like to restart the application right now?"
 msgstr ""
-"Se ha cambiado el idioma de Bookworm.\n"
-"Para que los cambios surtan efecto, necesitará reiniciar la aplicación.\n"
-"¿Le gustaría reiniciarla ahora?"
+"Has cambiado el idioma de pantalla de Bookworm.\n"
+"Para que esta opción tenga efecto completo, necesitas reiniciar la "
+"aplicación.\n"
+"¿Te gustaría reiniciar la aplicación ahora?"
 
 #. Translators: the title of a message telling the user
 #. that the display language have been changed
-#: bookworm/gui/settings.py:309
+#: bookworm/gui/settings.py:373
 msgid "Language Changed"
-msgstr "Idioma cambiado"
+msgstr "El idioma se cambió"
 
 #. Translators: the title of a group of controls in the
 #. appearance settings page related to the UI
-#: bookworm/gui/settings.py:331
-msgid "Text Styling"
-msgstr ""
+#: bookworm/gui/settings.py:395
+msgid "General Appearance"
+msgstr "Apariencia General"
 
 #. Translators: the label of a checkbox
-#: bookworm/gui/settings.py:336
+#: bookworm/gui/settings.py:400
+msgid "Maximize the application window upon startup"
+msgstr "Maximizar la ventana de la aplicación al iniciarse"
+
+#. Translators: the label of a checkbox
+#: bookworm/gui/settings.py:407
+msgid "Show the application's toolbar"
+msgstr "Actualizar la aplicación"
+
+#: bookworm/gui/settings.py:410
+msgid "Text Styling"
+msgstr "Estilos de Texto"
+
+#. Translators: the label of a checkbox
+#: bookworm/gui/settings.py:415
 msgid "Apply text styling (when available)"
-msgstr ""
+msgstr "Aplicar estilo de texto (cuando esté disponible)"
+
+#: bookworm/gui/settings.py:418
+msgid "Text view margins percentage"
+msgstr "Porcentaje de progreso en la lectura"
 
 #. Translators: the title of a group of controls in the
-#. appearance settings page related to the UI
-#: bookworm/gui/settings.py:341
+#. appearance settings page related to the font
+#: bookworm/gui/settings.py:422
 msgid "Font"
-msgstr ""
-
-#. Translators: label of a combobox
-#: bookworm/gui/settings.py:343
-msgid "Font Face"
-msgstr ""
+msgstr "Fuente"
 
 #. Translators: label of a checkbox
-#: bookworm/gui/settings.py:353
+#: bookworm/gui/settings.py:427
 msgid "Use Open-&dyslexic font"
-msgstr ""
+msgstr "Utilizar la fuente Open-&dyslexic"
 
-#. Translators: label of an edit box
-#: bookworm/gui/settings.py:357
+#. Translators: label of a combobox
+#: bookworm/gui/settings.py:431
+msgid "Font Face"
+msgstr "Tipo de Fuente"
+
+#. Translators: label of an static
+#: bookworm/gui/settings.py:438
 msgid "Font Size"
+msgstr "Tamaño de Fuente"
+
+#. Translators: the label of a checkbox
+#: bookworm/gui/settings.py:444
+msgid "Bold style"
+msgstr "Estilo Negrita"
+
+#. Translators: label of a button
+#: bookworm/gui/settings.py:504
+msgid "Download Pandoc: The universal document converter"
+msgstr "Descargar Pandoc: El conversor universal de documentos"
+
+#. Translators: description of a button
+#: bookworm/gui/settings.py:506
+msgid ""
+"Add support for additional document formats including RTF and Word 2003 "
+"documents."
 msgstr ""
+"Añade el soporte para formatos de documento adicionales incluyendo "
+"documentos RTF y Word 2003."
+
+#. Translators: label of a button
+#: bookworm/gui/settings.py:516
+msgid "Update Pandoc (the universal document converter)"
+msgstr "Actualizar Pandoc (el conversor universal de documentos)"
+
+#. Translators: description of a button
+#: bookworm/gui/settings.py:518
+msgid ""
+"Update Pandoc to the latest version to improve performance and conversion "
+"quality."
+msgstr ""
+"Actualiza Pandoc a la última versión para mejorar el rendimiento y la "
+"calidad de la conversión."
+
+#. Translators: the title of a group of controls in the
+#. advanced settings page
+#. Translators: label of a button
+#: bookworm/gui/settings.py:525 bookworm/gui/settings.py:530
+msgid "Reset Settings"
+msgstr "Opciones de Reinicio"
+
+#. Translators: description of a button
+#: bookworm/gui/settings.py:532
+msgid "Reset Bookworm's settings to their defaults"
+msgstr "Reinicia las opciones de Bookworm a sus valores predeterminados"
+
+#. Translators: title of a progress dialog
+#: bookworm/gui/settings.py:540
+msgid "Downloading Pandoc"
+msgstr "Descargando Pandoc"
+
+#. Translators: message of a progress dialog
+#. Translators: content of a progress dialog
+#: bookworm/gui/settings.py:542 bookworm/ocr/ocr_dialogs.py:141
+#: bookworm/ocr/ocr_dialogs.py:556
+msgid "Getting download information..."
+msgstr "Obteniendo información de descarga..."
+
+#. Translators: message of a dialog
+#: bookworm/gui/settings.py:555 bookworm/ocr/ocr_dialogs.py:174
+msgid "Checking for updates. Please wait..."
+msgstr "Comprobando actualizaciones. Por favor espera..."
+
+#. Translators: content of a message box
+#: bookworm/gui/settings.py:563
+msgid ""
+"You will lose  all of your custom settings.\n"
+"Are you sure you want to restore all settings to their default values?"
+msgstr ""
+"Perderás todos tus ajustes personalizados.\n"
+"¿Estás seguro de que quieres restaurar todos los ajustes a sus valores "
+"predeterminados?"
+
+#. Translators: title of a message box
+#: bookworm/gui/settings.py:567
+msgid "Reset Settings?"
+msgstr "¿Reiniciar Opciones?"
+
+#. Translators: title of a message box
+#: bookworm/gui/settings.py:580 bookworm/ocr/ocr_dialogs.py:161
+msgid "Restart Required"
+msgstr "Se Requiere el Reinicio"
+
+#. Translators: content of a message box
+#: bookworm/gui/settings.py:582
+msgid "Bookworm will now restart to complete the installation of Pandoc."
+msgstr "Bookworm ahora se reiniciará para completar la instalación de Pandoc."
+
+#. Translators: content of a message box
+#: bookworm/gui/settings.py:591
+msgid ""
+"A new version of Pandoc is available for download.\n"
+"It is strongly recommended to update to the latest version for the best "
+"performance and conversion quality.\n"
+"Would you like to update to the new version?"
+msgstr ""
+"Ya está disponible para su descarga una nueva versión de Pandoc.\n"
+"Se recomienda encarecidamente actualizar a la última versión para obtener el "
+"mejor rendimiento y calidad de conversión.\n"
+"¿Deseas actualizar a la nueva versión?"
+
+#. Translators: title of a message box
+#: bookworm/gui/settings.py:595
+msgid "Update Pandoc?"
+msgstr "¿Actualizar Pandoc?"
+
+#. Translators: message of a dialog
+#: bookworm/gui/settings.py:604
+msgid "Removing old Pandoc version. Please wait..."
+msgstr "Eliminando la versión antigua de Pandoc. Por favor espera..."
+
+#. Translators: content of a message box
+#: bookworm/gui/settings.py:610
+msgid "Your version of Pandoc is up to date."
+msgstr "Tu versión de Pandoc está actualizada."
+
+#. Translators: title of a message box
+#: bookworm/gui/settings.py:612 bookworm/ocr/ocr_dialogs.py:204
+msgid "No updates"
+msgstr "No hay actualizaciones"
+
+#. Translators: content of a message box
+#: bookworm/gui/settings.py:619
+msgid "Failed to check for updates. Please check your internet connection."
+msgstr ""
+"Error al comprobar actualizaciones. Por favor verifica tu conexión a "
+"internet."
 
 #. Translators: the label of a page in the settings dialog
-#: bookworm/gui/settings.py:406
-msgid "General"
-msgstr "General"
-
-#. Translators: the label of a page in the settings dialog
-#: bookworm/gui/settings.py:408
+#: bookworm/gui/settings.py:636
 msgid "Appearance"
-msgstr ""
+msgstr "Apariencia"
 
-#. Translators: label of the settings categories list box
-#: bookworm/gui/settings.py:436
-msgid "Categories"
-msgstr ""
+#. Translators: the label of a page in the settings dialog
+#: bookworm/gui/settings.py:638
+msgid "Advanced"
+msgstr "Avanzado"
 
 #. Translators: the label of the apply button in a dialog
-#: bookworm/gui/settings.py:465
+#: bookworm/gui/settings.py:695
 msgid "Apply"
 msgstr "Aplicar"
 
-#: bookworm/gui/book_viewer/__init__.py:76
+#: bookworm/gui/book_viewer/__init__.py:86
 msgid "Failed to open document"
-msgstr ""
+msgstr "Error al abrir documento"
 
-#: bookworm/gui/book_viewer/__init__.py:77
+#: bookworm/gui/book_viewer/__init__.py:87
 msgid "The document you are trying to open could not be opened in Bookworm."
 msgstr ""
+"El documento que estás intentando abrir no se ha podido abrir en Bookworm."
 
-#: bookworm/gui/book_viewer/__init__.py:93
+#: bookworm/gui/book_viewer/__init__.py:101
 msgid "Opening document, please wait..."
-msgstr ""
+msgstr "Abriendo documento, por favor espera..."
 
 #. Translators: the title of an error message
-#: bookworm/gui/book_viewer/__init__.py:106
+#: bookworm/gui/book_viewer/__init__.py:119
 msgid "Document not found"
-msgstr ""
+msgstr "Documento no encontrado"
 
 #. Translators: the content of an error message
-#: bookworm/gui/book_viewer/__init__.py:108
+#: bookworm/gui/book_viewer/__init__.py:121
 msgid ""
 "Could not open Document.\n"
 "The document does not exist."
 msgstr ""
+"No se ha podido abrir el documento.\n"
+"El documento no existe."
+
+#. Translators: the title of an error message
+#: bookworm/gui/book_viewer/__init__.py:133
+msgid "Document Restricted"
+msgstr "Documento restringido"
+
+#. Translators: the content of an error message
+#: bookworm/gui/book_viewer/__init__.py:135
+msgid ""
+"Could not open Document.\n"
+"The document is restricted by the publisher."
+msgstr ""
+"No se ha podido abrir el documento.\n"
+"El documento está restringido por el editor."
 
 #. Translators: the title of a message shown
 #. when the format of the e-book is not supported
-#: bookworm/gui/book_viewer/__init__.py:118
+#: bookworm/gui/book_viewer/__init__.py:147
 msgid "Unsupported Document Format"
-msgstr "Documento de archivo no soportado"
+msgstr "Formato de Documento no Admitido"
 
 #. Translators: the content of a message shown
 #. when the format of the e-book is not supported
-#: bookworm/gui/book_viewer/__init__.py:121
+#: bookworm/gui/book_viewer/__init__.py:150
 msgid "The format of the given document is not supported by Bookworm."
-msgstr "El formato del documento especificado no se soporta por Bookworm."
+msgstr "El formato del documento dado no es compatible con Bookworm."
 
 #. Translators: the title of an error message
-#: bookworm/gui/book_viewer/__init__.py:130
-#, fuzzy
-msgid "Error Opening Document"
-msgstr "Error al abrir el documento"
+#: bookworm/gui/book_viewer/__init__.py:159
+msgid "Archive contains no documents"
+msgstr "El archivo no contiene documentos"
 
 #. Translators: the content of an error message
-#: bookworm/gui/book_viewer/__init__.py:132
-#, fuzzy
+#: bookworm/gui/book_viewer/__init__.py:161
+msgid ""
+"Bookworm cannot open this archive file.\n"
+"The archive contains no documents."
+msgstr ""
+"Bookworm no puede abrir este archivo de ficheros.\n"
+"El archivo no contiene documentos."
+
+#: bookworm/gui/book_viewer/__init__.py:170
+msgid "Documents"
+msgstr "Documentos"
+
+#: bookworm/gui/book_viewer/__init__.py:171
+msgid "Multiple documents found"
+msgstr "Encontrados varios documentos"
+
+#. Translators: the title of an error message
+#: bookworm/gui/book_viewer/__init__.py:185
+msgid "Error Opening Document"
+msgstr "Error Abriendo Documento"
+
+#. Translators: the content of an error message
+#: bookworm/gui/book_viewer/__init__.py:187
 msgid ""
 "Could not open file\n"
-".Either the file  has been damaged during download, or it has been "
-"corrupted in some other way."
-msgstr "T"
+".Either the file  has been damaged during download, or it has been corrupted "
+"in some other way."
+msgstr ""
+"No se ha podido abrir el archivo\n"
+"O bien el archivo se ha dañado durante la descarga, o se ha corrompido de "
+"alguna otra manera."
 
 #. Translators: the title of an error message
-#: bookworm/gui/book_viewer/__init__.py:145
+#: bookworm/gui/book_viewer/__init__.py:200
 msgid "Error Openning Document"
-msgstr "Error al abrir el documento"
+msgstr "Error Abriendo Documento"
 
 #. Translators: the content of an error message
-#: bookworm/gui/book_viewer/__init__.py:147
+#: bookworm/gui/book_viewer/__init__.py:202
 msgid ""
 "Could not open document.\n"
 "An unknown error occurred while loading the file."
 msgstr ""
+"No se ha podido abrir el documento.\n"
+"Se ha producido un error desconocido al cargar el archivo."
+
+#. Translators: content of a message
+#: bookworm/gui/book_viewer/__init__.py:214
+msgid ""
+"Failed to open document.\n"
+"Would you like to remove its entry from the 'recent documents' and 'pinned "
+"documents' lists?"
+msgstr ""
+"Error al abrir el documento.\n"
+"¿Quieres eliminar su entrada de las listas de \"documentos recientes\" y de "
+"\"documentos fijados\"?"
+
+#. Translators: title of a message box
+#: bookworm/gui/book_viewer/__init__.py:218
+msgid "Remove from lists?"
+msgstr "¿Eliminar de las listas?"
 
 #. Translators: the text of the status bar when no book is currently open.
 #. It is being used also as a label for the page content text area when no book
 #. is opened.
-#: bookworm/gui/book_viewer/__init__.py:218
-#, fuzzy
+#: bookworm/gui/book_viewer/__init__.py:287
 msgid "Press (Ctrl + O) to open a document"
-msgstr "Presione (Ctrl + O) para abrir un ebook"
+msgstr "Pulsa (Ctrl + O) para abrir un documento"
 
 #. Translators: the label of the table-of-contents tree
-#: bookworm/gui/book_viewer/__init__.py:232
+#: bookworm/gui/book_viewer/__init__.py:301
 msgid "Table of Contents"
-msgstr "Tabla de contenido"
+msgstr "Índice"
+
+#: bookworm/gui/book_viewer/__init__.py:324
+msgid "Reading progress percentage"
+msgstr "Porcentaje de progreso en la lectura"
 
 #. Translators: the label of a button in the application toolbar
-#: bookworm/gui/book_viewer/__init__.py:305
+#: bookworm/gui/book_viewer/__init__.py:409
 msgid "Open"
 msgstr "Abrir"
 
 #. Translators: the label of a button in the application toolbar
-#: bookworm/gui/book_viewer/__init__.py:308
-msgid "Search"
-msgstr "Buscar"
-
-#. Translators: the label of a button in the application toolbar
-#: bookworm/gui/book_viewer/__init__.py:310
+#: bookworm/gui/book_viewer/__init__.py:414
 msgid "Mode"
-msgstr ""
+msgstr "Modo"
 
 #. Translators: the label of a button in the application toolbar
-#: bookworm/gui/book_viewer/__init__.py:313
+#: bookworm/gui/book_viewer/__init__.py:417
 msgid "Big"
-msgstr ""
+msgstr "Grande"
 
 #. Translators: the label of a button in the application toolbar
-#: bookworm/gui/book_viewer/__init__.py:315
+#: bookworm/gui/book_viewer/__init__.py:419
 msgid "Small"
+msgstr "Pequeño"
+
+#. Translators: title of a message telling the user that they entered an
+#. incorrect
+#. password for opening the book
+#: bookworm/gui/book_viewer/__init__.py:464
+msgid "Incorrect Password"
+msgstr "Contraseña Incorrecta"
+
+#. Translators: content of a message telling the user that they entered an
+#. incorrect
+#. password for opening the book
+#: bookworm/gui/book_viewer/__init__.py:467
+msgid ""
+"The password you provided is incorrect.\n"
+"Please try again with the correct password."
 msgstr ""
+"La contraseña proporcionada es incorrecta.\n"
+"Inténtalo de nuevo con la contraseña correcta."
+
+#. Translators: spoken message when the document has been closed
+#: bookworm/gui/book_viewer/__init__.py:528
+msgid "Document closed."
+msgstr "Documento cerrado."
+
+#. Translators: text of reading progress shown in the status bar
+#: bookworm/gui/book_viewer/__init__.py:565
+msgid "{percentage} completed"
+msgstr "{percentage} completado"
 
 #. Translators: label of content text control when the currently opened
 #. document is a single page document
-#: bookworm/gui/book_viewer/__init__.py:432
+#: bookworm/gui/book_viewer/__init__.py:623
 msgid "Document content"
-msgstr ""
+msgstr "Contenido del Documento"
 
-#. Translators: the label of the page content text area
-#: bookworm/gui/book_viewer/__init__.py:440
-#, fuzzy
-msgid "Page {page} of {total} — {chapter}"
-msgstr "Página {page} de {total}"
-
-#. Translators: a message that is announced after navigating to a page
-#. Translators: a message to announce when navigating to another page
-#: bookworm/gui/book_viewer/__init__.py:454
-#: bookworm/text_to_speech/__init__.py:182
-msgid "Page {page} of {total}"
-msgstr "Página {page} de {total}"
-
-#: bookworm/gui/book_viewer/__init__.py:496
+#: bookworm/gui/book_viewer/__init__.py:654
 msgid "{text}: {item_type}"
-msgstr ""
+msgstr "{text}: {item_type}"
 
-#: bookworm/gui/book_viewer/__init__.py:510
+#: bookworm/gui/book_viewer/__init__.py:671
 msgid "No next {item}"
-msgstr ""
+msgstr "No hay siguiente {item}"
 
-#: bookworm/gui/book_viewer/__init__.py:512
+#: bookworm/gui/book_viewer/__init__.py:673
 msgid "No previous {item}"
-msgstr ""
+msgstr "No hay anterior {item}"
 
 #. Translators: a message telling the user that the font size has been
 #. increased
-#: bookworm/gui/book_viewer/__init__.py:528
+#: bookworm/gui/book_viewer/__init__.py:689
 msgid "The font size has been Increased"
-msgstr ""
-"Se ha incrementado el tamaño de fuente\n"
-"\\v"
+msgstr "El tamaño de la fuente se ha aumentado"
 
 #. Translators: a message telling the user that the font size has been
 #. decreased
-#: bookworm/gui/book_viewer/__init__.py:534
+#: bookworm/gui/book_viewer/__init__.py:695
 msgid "The font size has been decreased"
-msgstr "Se ha disminuido el tamaño de fuente"
+msgstr "El tamaño de la fuente se ha disminuido"
 
 #. Translators: a message telling the user that the font size has been reset
-#: bookworm/gui/book_viewer/__init__.py:538
+#: bookworm/gui/book_viewer/__init__.py:699
 msgid "The font size has been reset"
-msgstr "Se restableció el tamaño de fuente"
+msgstr "El tamaño de la fuente se ha reiniciado"
+
+#: bookworm/gui/book_viewer/__init__.py:729
+msgid "Reading progress: {percentage}"
+msgstr "Progreso de lectura: {percentage}"
 
 #. Translators: the content of a dialog asking the user
 #. for the password to decrypt the current e-book
-#: bookworm/gui/book_viewer/__init__.py:559
-#, fuzzy
+#: bookworm/gui/book_viewer/__init__.py:750
 msgid ""
 "This document is encrypted with a password.\n"
 "You need to provide the password in order to access its content.\n"
 "Please provide the password and press enter."
 msgstr ""
-"Este documento se encuentra encriptado, por lo que necesita de la "
-"contraseña para acceder al contenido.\n"
-"Por favor, introduzca la contraseña abajo y presione enter."
+"Este documento está encriptado con una contraseña.\n"
+"Para acceder a su contenido, debes introducir la contraseña.\n"
+"Introduce la contraseña y pulsa Intro."
 
 #. Translators: the title of a dialog asking the user to enter a password to
 #. decrypt the e-book
-#: bookworm/gui/book_viewer/__init__.py:565
-#, fuzzy
+#: bookworm/gui/book_viewer/__init__.py:756
 msgid "Enter Password"
-msgstr "Contraseña inválida"
+msgstr "Introducir Contraseña"
 
-#. Translators: title of a message telling the user that they entered an
-#. incorrect
-#. password for opening the book
-#: bookworm/gui/book_viewer/__init__.py:575
-msgid "Incorrect Password"
-msgstr ""
+#. Translators: the label of the page content text area
+#. Translators: a message to announce when navigating to another page
+#: bookworm/gui/book_viewer/__init__.py:794
+#: bookworm/text_to_speech/__init__.py:179
+msgid "Page {page} of {total}"
+msgstr "Página {page} de {total}"
 
-#. Translators: content of a message telling the user that they entered an
-#. incorrect
-#. password for opening the book
-#: bookworm/gui/book_viewer/__init__.py:578
-#, fuzzy
-msgid ""
-"The password you provided is incorrect.\n"
-"Please try again with the correct password."
-msgstr ""
-"La contraseña que ha ingresado es incorrecta.\n"
-"Por favor, intente nuevamente."
+#: bookworm/gui/book_viewer/__init__.py:879
+msgid "Opening page: {url}"
+msgstr "Abriendo página: {url}"
 
 #. Translators: the label of a list of search results
-#: bookworm/gui/book_viewer/core_dialogs.py:38
+#: bookworm/gui/book_viewer/core_dialogs.py:56
 msgid "Search Results"
-msgstr "Resultados de la búsqueda"
+msgstr "Resultados de la Búsqueda"
 
 #. Translators: the title of a column in the search results list showing
 #. an excerpt of the text of the search result
-#: bookworm/gui/book_viewer/core_dialogs.py:49
+#: bookworm/gui/book_viewer/core_dialogs.py:67
 msgid "Text"
 msgstr "Texto"
 
 #. Translators: the label of a progress bar indicating the progress of the
 #. search process
-#: bookworm/gui/book_viewer/core_dialogs.py:65
+#: bookworm/gui/book_viewer/core_dialogs.py:83
 msgid "Search Progress:"
-msgstr "Progreso de la búsqueda"
+msgstr "Progreso de la Búsqueda:"
 
 #. Translators: the label of a button to close the dialog
 #. Translators: the label of an edit field in the search dialog
-#: bookworm/gui/book_viewer/core_dialogs.py:139
+#: bookworm/gui/book_viewer/core_dialogs.py:157
 msgid "Search term:"
 msgstr "Término de búsqueda:"
 
 #. Translators: the label of a checkbox
-#: bookworm/gui/book_viewer/core_dialogs.py:145
+#: bookworm/gui/book_viewer/core_dialogs.py:163
 msgid "Case sensitive"
-msgstr "Sensible a mayúsculas"
+msgstr "Sensible a las mayúsculas"
 
 #. Translators: the label of a checkbox
-#: bookworm/gui/book_viewer/core_dialogs.py:147
+#: bookworm/gui/book_viewer/core_dialogs.py:165
 msgid "Match whole word only"
-msgstr "Sólo palabras completas"
+msgstr "Coincidir Sólo palabras completas"
 
 #. Translators: the label of a checkbox
-#: bookworm/gui/book_viewer/core_dialogs.py:149
+#: bookworm/gui/book_viewer/core_dialogs.py:167
 msgid "Regular expression"
-msgstr ""
+msgstr "Expresión Regular"
 
-#: bookworm/gui/book_viewer/core_dialogs.py:198
+#: bookworm/gui/book_viewer/core_dialogs.py:216
 msgid "Page number, of {total}:"
 msgstr "Número de página, de {total}:"
 
+#: bookworm/gui/book_viewer/core_dialogs.py:255
+msgid "Element Type"
+msgstr "Elementos"
+
+#: bookworm/gui/book_viewer/core_dialogs.py:260
+msgid "Elements"
+msgstr "Elementos"
+
+#. Translators: title of a dialog
+#: bookworm/gui/book_viewer/core_dialogs.py:336
+msgid "Document Info"
+msgstr "Información de Documento"
+
+#: bookworm/gui/book_viewer/core_dialogs.py:365
+msgid "Author"
+msgstr "Autor"
+
+#: bookworm/gui/book_viewer/core_dialogs.py:369
+msgid "Description"
+msgstr "Descripción"
+
+#: bookworm/gui/book_viewer/core_dialogs.py:378
+msgid "Number of Sections"
+msgstr "Número de Secciones"
+
+#: bookworm/gui/book_viewer/core_dialogs.py:382
+msgid "Number of Pages"
+msgstr "Número de Páginas"
+
+#. Translators: the title of a column in the Tesseract language list
+#: bookworm/gui/book_viewer/core_dialogs.py:385 bookworm/ocr/ocr_dialogs.py:496
+msgid "Language"
+msgstr "Idioma"
+
+#: bookworm/gui/book_viewer/core_dialogs.py:388
+msgid "Publisher"
+msgstr "Editorial"
+
+#: bookworm/gui/book_viewer/core_dialogs.py:390
+msgid "Created at"
+msgstr "Creado en"
+
+#: bookworm/gui/book_viewer/core_dialogs.py:393
+msgid "Publication Date"
+msgstr "Fecha de Publicación"
+
 #. Translators: the content of the about message
-#: bookworm/gui/book_viewer/menubar.py:48
+#: bookworm/gui/book_viewer/menubar.py:52
 msgid ""
 "{display_name}\n"
 "Version: {version}\n"
 "Website: {website}\n"
 "\n"
-"{display_name} is an accessible document reader that enables blind and "
-"visually impaired individuals to read documents in an easy, accessible, "
-"and hassle-free manor. It is being developed by {author} with some "
-"contributions from the community.\n"
+"{display_name} is an advanced and accessible document reader that enables "
+"blind and visually impaired individuals to read documents in an easy, "
+"accessible, and hassle-free manor. It is being developed by {author} with "
+"some contributions from the community.\n"
 "\n"
 "{copyright}\n"
-"This software is offered to you under the terms of The MIT license.\n"
-"You can view the license text from the help menu.\n"
+"{display_name} is free software; you can redistribute it and/or modify it "
+"under the terms of the GNU General Public License as published by the Free "
+"Software Foundation; either version 2 of the License, or (at your option) "
+"any later version.\n"
+"This program is distributed in the hope that it will be useful, but WITHOUT "
+"ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or "
+"FITNESS FOR A PARTICULAR PURPOSE.\n"
+"For further details, you can view the full licence from the help menu.\n"
+msgstr ""
+"{display_name}\n"
+"Versión: {version}\n"
+"Sitio Web: {website}\n"
 "\n"
-msgstr ""
+"{display_name} es un lector de documentos avanzado y accesible que permite a "
+"las personas ciegas y con discapacidad visual leer documentos de una manera "
+"fácil, accesible y sin complicaciones. Está siendo desarrollado por  "
+"{author} con algunas contribuciones de la comunidad.\n"
+"\n"
+"{copyright}\n"
+"\n"
+"{display_name} es software libre; puedes redistribuirlo y/o modificarlo bajo "
+"los términos de la Licencia Pública General GNU publicada por la Free "
+"Software Foundation; ya sea la versión 2 de la Licencia, o (a tu elección) "
+"cualquier versión posterior.\n"
+"Este programa se distribuye con la esperanza de que sea útil, pero SIN "
+"NINGUNA GARANTÍA; ni siquiera la garantía implícita de COMERCIABILIDAD o "
+"IDONEIDAD PARA UN PROPÓSITO PARTICULAR.\n"
+"Para más detalles, puedes consultar la licencia completa en el menú de "
+"ayuda.\n"
 
-#: bookworm/gui/book_viewer/menubar.py:59
+#: bookworm/gui/book_viewer/menubar.py:64
 msgid ""
-"This release of Bookworm is generously sponsored  by Capeds "
-"(www.capeds.net)."
+"This release of Bookworm is generously sponsored  by Capeds (www.capeds.net)."
 msgstr ""
+"Esta edición de Bookworm está generosamente patrocinada por Capeds (www."
+"capeds.net)."
 
 #. Translators: the label of an item in the application menubar
-#: bookworm/gui/book_viewer/menubar.py:89
+#: bookworm/gui/book_viewer/menubar.py:94
 msgid "Open...\tCtrl-O"
 msgstr "Abrir...\tCtrl-O"
 
-#: bookworm/gui/book_viewer/menubar.py:93
-msgid "&Pin\tCtrl-P"
-msgstr ""
-
 #. Translators: the label of an item in the application menubar
 #: bookworm/gui/book_viewer/menubar.py:96
-msgid "&Save As Plain Text..."
-msgstr "&Guardar como texto plano..."
+msgid "New Window...\tCtrl-N"
+msgstr "Ventana Nueva...\tCtrl-N"
+
+#: bookworm/gui/book_viewer/menubar.py:100
+msgid "&Pin\tCtrl-P"
+msgstr "Pi&n\tCtrl-P"
 
 #. Translators: the label of an item in the application menubar
-#: bookworm/gui/book_viewer/menubar.py:101
-#, fuzzy
-msgid "&Close Current Document\tCtrl-W"
-msgstr "&Cerrar el libro actual\tCtrl-W"
-
-#. Translators: the help text of an item in the application menubar
 #: bookworm/gui/book_viewer/menubar.py:103
-#, fuzzy
+msgid "&Save As Plain Text..."
+msgstr "&Guardar como Texto Plano..."
+
+#. Translators: the label of an item in the application menubar
+#: bookworm/gui/book_viewer/menubar.py:108
+msgid "&Close Current Document\tCtrl-W"
+msgstr "&Cerrar Documento Actual\tCtrl-W"
+
+#. Translators: the help text of an item in the application menubar
+#: bookworm/gui/book_viewer/menubar.py:110
 msgid "Close the currently open document"
-msgstr "Cierra el libro actualmente abierto"
+msgstr "Cerrar el documento actualmente abierto"
 
 #. Translators: the label of an item in the application menubar
-#: bookworm/gui/book_viewer/menubar.py:109
-msgid "Pi&nned Documents"
+#: bookworm/gui/book_viewer/menubar.py:116
+msgid "C&lear Documents Cache..."
+msgstr "&Borrar Caché de Documentos..."
+
+#. Translators: the help text of an item in the application menubar
+#: bookworm/gui/book_viewer/menubar.py:118
+msgid ""
+"Clear the document cache. Helps in fixing some issues with openning "
+"documents."
 msgstr ""
-
-#. Translators: the help text of an item in the application menubar
-#: bookworm/gui/book_viewer/menubar.py:111
-#, fuzzy
-msgid "Opens a list of documents you pinned."
-msgstr "Abre una lista con los Ebooks más recientes"
+"Borra la caché de los documentos. Ayuda a solucionar algunos problemas al "
+"abrirlos."
 
 #. Translators: the label of an item in the application menubar
-#: bookworm/gui/book_viewer/menubar.py:117
-#: bookworm/gui/book_viewer/menubar.py:131
-msgid "Clear list"
-msgstr "Limpiar lista"
-
-#. Translators: the help text of an item in the application menubar
-#: bookworm/gui/book_viewer/menubar.py:119
-#, fuzzy
-msgid "Clear the pinned documents list"
-msgstr "Limpia la lista de Ebooks más recientes"
-
-#. Translators: the label of an item in the application menubar
-#: bookworm/gui/book_viewer/menubar.py:124
-msgid "&Recently Opened"
-msgstr ""
-
-#. Translators: the help text of an item in the application menubar
 #: bookworm/gui/book_viewer/menubar.py:126
-msgid "Opens a list of recently opened books."
-msgstr "Abre una lista con los Ebooks más recientes"
+msgid "Pi&nned Documents"
+msgstr "&Fijar Documentos"
 
 #. Translators: the help text of an item in the application menubar
-#: bookworm/gui/book_viewer/menubar.py:133
-msgid "Clear the recent books list."
-msgstr "Limpia la lista de Ebooks más recientes"
+#: bookworm/gui/book_viewer/menubar.py:128
+msgid "Opens a list of documents you pinned."
+msgstr "Abre una lista de documentos que fijaste."
 
 #. Translators: the label of an item in the application menubar
-#: bookworm/gui/book_viewer/menubar.py:139
+#: bookworm/gui/book_viewer/menubar.py:134
+#: bookworm/gui/book_viewer/menubar.py:148
+msgid "Clear list"
+msgstr "Borrar lista"
+
+#. Translators: the help text of an item in the application menubar
+#: bookworm/gui/book_viewer/menubar.py:136
+msgid "Clear the pinned documents list"
+msgstr "Borrar la lista de documentos fijados"
+
+#. Translators: the label of an item in the application menubar
+#: bookworm/gui/book_viewer/menubar.py:141
+msgid "&Recently Opened"
+msgstr "Abiertos &Recientemente"
+
+#. Translators: the help text of an item in the application menubar
+#: bookworm/gui/book_viewer/menubar.py:143
+msgid "Opens a list of recently opened books."
+msgstr "Abre una lista de libros abiertos recientemente."
+
+#. Translators: the help text of an item in the application menubar
+#: bookworm/gui/book_viewer/menubar.py:150
+msgid "Clear the recent books list."
+msgstr "Borrar la lista de libros recientes."
+
+#. Translators: the label of an item in the application menubar
+#: bookworm/gui/book_viewer/menubar.py:156
 msgid "&Preferences...\tCtrl-Shift-P"
 msgstr "&Preferencias...\tCtrl-Shift-P"
 
 #. Translators: the help text of an item in the application menubar
-#: bookworm/gui/book_viewer/menubar.py:141
+#: bookworm/gui/book_viewer/menubar.py:158
 msgid "Configure application"
-msgstr "Configura la aplicación"
+msgstr "Configurar aplicación"
 
 #. Translators: the label of an item in the application menubar
-#: bookworm/gui/book_viewer/menubar.py:145
+#: bookworm/gui/book_viewer/menubar.py:162
 msgid "Exit"
 msgstr "Salir"
 
 #. Translators: the title of a file dialog to browse to a document
-#: bookworm/gui/book_viewer/menubar.py:187
-#, fuzzy
+#: bookworm/gui/book_viewer/menubar.py:213
 msgid "Select a document"
-msgstr "Seleccionar una voz"
+msgstr "Seleccionar un documento"
+
+#: bookworm/gui/book_viewer/menubar.py:242
+msgid "Pinned"
+msgstr "Fijado"
+
+#: bookworm/gui/book_viewer/menubar.py:246
+msgid "Unpinned"
+msgstr "No fijado"
 
 #. Translators: the title of a dialog showing
 #. the progress of book export process
-#: bookworm/gui/book_viewer/menubar.py:236
-#, fuzzy
+#: bookworm/gui/book_viewer/menubar.py:272
 msgid "Exporting Document"
-msgstr "Error al abrir el documento"
+msgstr "Exportando Documento"
 
 #. Translators: the message of a dialog showing the progress of book export
-#: bookworm/gui/book_viewer/menubar.py:238
-#, fuzzy
+#: bookworm/gui/book_viewer/menubar.py:274
 msgid "Converting document to plain text."
-msgstr "Convirtiendo el libro a texto plano."
+msgstr "Convirtiendo documento a texto plano."
 
 #. Translators: a message shown when the book is being exported
-#: bookworm/gui/book_viewer/menubar.py:253
-#, fuzzy
+#: bookworm/gui/book_viewer/menubar.py:292
 msgid "Exporting Page {current} of {total}..."
-msgstr "Página {page} de {total}"
+msgstr "Exportando Página {current} de {total}..."
 
 #. Translators: the title of the application preferences dialog
-#: bookworm/gui/book_viewer/menubar.py:274
+#: bookworm/gui/book_viewer/menubar.py:314
 msgid "{app_name} Preferences"
-msgstr "Preferencias de {app_name}"
+msgstr "{app_name} Preferencias"
+
+#. Translators: content of a message
+#: bookworm/gui/book_viewer/menubar.py:325
+msgid "Are you sure you want to clear the documents cache?"
+msgstr "¿Estás seguro de que quieres borrar la caché de documentos?"
+
+#. Translators: title of a message box
+#: bookworm/gui/book_viewer/menubar.py:327
+msgid "Clear Documents Cache?"
+msgstr "¿Borrar la caché de documentos?"
+
+#. Translators: content of a message box
+#: bookworm/gui/book_viewer/menubar.py:335
+msgid "Documents cache has been cleared."
+msgstr "La Caché de documentos se ha borrado."
+
+#. Translators: content of a message in a message box
+#: bookworm/gui/book_viewer/menubar.py:344
+msgid "Clearing documents cache..."
+msgstr "Borrando la caché de documentos..."
 
 #. Translators: the label of an item in the application menubar
-#: bookworm/gui/book_viewer/menubar.py:322
+#: bookworm/gui/book_viewer/menubar.py:388
 msgid "(No recent books)"
 msgstr "(No hay libros recientes)"
 
-#: bookworm/gui/book_viewer/menubar.py:323
+#: bookworm/gui/book_viewer/menubar.py:389
 msgid "No recent books"
-msgstr "No hay libros recientes."
+msgstr "No hay libros recientes"
 
 #. Translators: the label of an item in the application menubar
-#: bookworm/gui/book_viewer/menubar.py:362
-#: bookworm/gui/book_viewer/menubar.py:776
-#, fuzzy
-msgid "&Find in Document...\tCtrl-F"
-msgstr "&Buscar en el libro...\tCtrl-F"
+#: bookworm/gui/book_viewer/menubar.py:426
+msgid "Document &Info..."
+msgstr "&Información de Documento..."
 
 #. Translators: the help text of an item in the application menubar
-#: bookworm/gui/book_viewer/menubar.py:364
-#: bookworm/gui/book_viewer/menubar.py:776
-#, fuzzy
-msgid "Search this document."
-msgstr "Busca en este libro."
-
-#. Translators: the label of an item in the application menubar
-#: bookworm/gui/book_viewer/menubar.py:369
-msgid "&Find &Next\tF3"
-msgstr "&Buscar &siguiente\tF3"
-
-#. Translators: the help text of an item in the application menubar
-#: bookworm/gui/book_viewer/menubar.py:371
-msgid "Find next occurrence."
-msgstr "Busca la ocurrencia siguiente."
-
-#. Translators: the label of an item in the application menubar
-#: bookworm/gui/book_viewer/menubar.py:376
-msgid "&Find &Previous\tShift-F3"
-msgstr "&Buscar &anterior\tShift-F3"
-
-#. Translators: the help text of an item in the application menubar
-#: bookworm/gui/book_viewer/menubar.py:378
-msgid "Find previous occurrence."
-msgstr "Busca la ocurrencia anterior"
-
-#. Translators: the label of an item in the application menubar
-#: bookworm/gui/book_viewer/menubar.py:383
-#: bookworm/gui/book_viewer/menubar.py:772
-msgid "&Go To Page...\tCtrl-G"
-msgstr "&Ir a la página...\tCtrl-G"
-
-#. Translators: the help text of an item in the application menubar
-#: bookworm/gui/book_viewer/menubar.py:385
-msgid "Go to page"
-msgstr "Ir a la página"
-
-#. Translators: the label of an item in the application menubar
-#: bookworm/gui/book_viewer/menubar.py:390
-msgid "&Go To Page By Label...\tCtrl-Shift-G"
+#: bookworm/gui/book_viewer/menubar.py:428
+msgid "Show information about number of chapters, word count..etc."
 msgstr ""
-
-#. Translators: the help text of an item in the application menubar
-#: bookworm/gui/book_viewer/menubar.py:392
-msgid "Go to a page using its label"
-msgstr ""
-
-#. Translators: the title of the go to page dialog
-#: bookworm/gui/book_viewer/menubar.py:417
-msgid "Go To Page"
-msgstr "Ir a la página"
-
-#: bookworm/gui/book_viewer/menubar.py:424
-#, fuzzy
-msgid "Go To Page By Label"
-msgstr "Ir a la página"
-
-#: bookworm/gui/book_viewer/menubar.py:424
-#, fuzzy
-msgid "Page Label"
-msgstr "Actualización disponible"
-
-#. Translators: the title of the search dialog
-#: bookworm/gui/book_viewer/menubar.py:432
-#, fuzzy
-msgid "Search Document"
-msgstr "Seleccionar una voz"
-
-#: bookworm/gui/book_viewer/menubar.py:458
-msgid "Searching For '{term}'"
-msgstr "Buscando \"{term}\""
-
-#. Translators: message to announce the number of search results
-#. also used as the final title of the search results dialog
-#: bookworm/gui/book_viewer/menubar.py:473
-msgid "Results | {total}"
-msgstr "Resultados | {total}"
+"Muestra información acerca del número de capítulos, cuenta de palabras, etc."
 
 #. Translators: the label of an item in the application menubar
-#: bookworm/gui/book_viewer/menubar.py:546
-#: bookworm/gui/book_viewer/menubar.py:783
-msgid "&Render Page...\tCtrl-R"
-msgstr "&Renderizar página...\tCtrl-R"
+#: bookworm/gui/book_viewer/menubar.py:433
+msgid "&Element list...\tCtrl+F7"
+msgstr "Lista de &Elementos...\tCtrl+F7"
 
 #. Translators: the help text of an item in the application menubar
-#: bookworm/gui/book_viewer/menubar.py:548
-#: bookworm/gui/book_viewer/menubar.py:784
-msgid "View a fully rendered version of this page."
-msgstr "Muestra una versión renderizada de la página"
+#: bookworm/gui/book_viewer/menubar.py:435
+msgid "Show a list of semantic elements."
+msgstr "Muestra una lista de elementos semánticos."
 
 #. Translators: the label of an item in the application menubar
-#: bookworm/gui/book_viewer/menubar.py:553
+#: bookworm/gui/book_viewer/menubar.py:440
 msgid "Change Reading &Mode...\tCtrl-Shift-M"
-msgstr ""
+msgstr "Cambiar &Modo de lectura...\tCtrl-Shift-M"
 
 #. Translators: the help text of an item in the application menubar
-#: bookworm/gui/book_viewer/menubar.py:555
-#, fuzzy
+#: bookworm/gui/book_viewer/menubar.py:442
 msgid "Change the current reading mode."
-msgstr "Leer la página actual"
+msgstr "Cambia el modo de lectura actual."
 
-#: bookworm/gui/book_viewer/menubar.py:587
+#. Translators: the label of an item in the application menubar
+#: bookworm/gui/book_viewer/menubar.py:447
+#: bookworm/gui/book_viewer/menubar.py:953
+msgid "&Render Page...\tCtrl-R"
+msgstr "&Renderizar Página...\tCtrl-R"
+
+#. Translators: the help text of an item in the application menubar
+#: bookworm/gui/book_viewer/menubar.py:449
+#: bookworm/gui/book_viewer/menubar.py:954
+msgid "View a fully rendered version of this page."
+msgstr "Ver una versión renderizada completa de esta página."
+
+#: bookworm/gui/book_viewer/menubar.py:491
 msgid "Rendered Page"
 msgstr "Página renderizada"
 
-#: bookworm/gui/book_viewer/menubar.py:604
+#: bookworm/gui/book_viewer/menubar.py:508
 msgid "Available reading modes"
-msgstr ""
+msgstr "Modos de lectura disponibles"
 
-#: bookworm/gui/book_viewer/menubar.py:605
-#, fuzzy
+#: bookworm/gui/book_viewer/menubar.py:509
 msgid "Select Reading Mode "
-msgstr "Usar modo de lectura continua"
+msgstr "Seleccionar modo de lectura "
+
+#: bookworm/gui/book_viewer/menubar.py:534
+msgid "Element List"
+msgstr "Lista de Elementos"
 
 #. Translators: the label of an item in the application menubar
-#: bookworm/gui/book_viewer/menubar.py:632
-msgid "&User guide...\tF1"
-msgstr "&Manual de usuario...\tF1"
+#: bookworm/gui/book_viewer/menubar.py:561
+#: bookworm/gui/book_viewer/menubar.py:943
+msgid "&Find in Document...\tCtrl-F"
+msgstr "&Buscar en Documento...\tCtrl-F"
 
 #. Translators: the help text of an item in the application menubar
+#: bookworm/gui/book_viewer/menubar.py:563
+#: bookworm/gui/book_viewer/menubar.py:944
+msgid "Search this document."
+msgstr "Buscar en este documento."
+
+#. Translators: the label of an item in the application menubar
+#: bookworm/gui/book_viewer/menubar.py:568
+msgid "Find &Next\tF3"
+msgstr "Buscar &Siguiente\tF3"
+
+#. Translators: the help text of an item in the application menubar
+#: bookworm/gui/book_viewer/menubar.py:570
+msgid "Find next occurrence."
+msgstr "Encuentra la siguiente ocurrencia."
+
+#. Translators: the label of an item in the application menubar
+#: bookworm/gui/book_viewer/menubar.py:575
+msgid "Find &Previous\tShift-F3"
+msgstr "Buscar &Anterior\tShift-F3"
+
+#. Translators: the help text of an item in the application menubar
+#: bookworm/gui/book_viewer/menubar.py:577
+msgid "Find previous occurrence."
+msgstr "Encuentra la ocurrencia anterior."
+
+#. Translators: the label of an item in the application menubar
+#: bookworm/gui/book_viewer/menubar.py:582
+msgid "&Jump to Line...\tCtrl-L"
+msgstr "Saltar a &Línea...\tCtrl-L"
+
+#. Translators: the help text of an item in the application menubar
+#: bookworm/gui/book_viewer/menubar.py:584
+msgid "Jump to a line within the current page or document"
+msgstr "Salta a una línea dentro de la página o documento actual"
+
+#. Translators: the label of an item in the application menubar
+#: bookworm/gui/book_viewer/menubar.py:589
+#: bookworm/gui/book_viewer/menubar.py:937
+msgid "&Go To Page...\tCtrl-G"
+msgstr "&Ir a Página...\tCtrl-G"
+
+#. Translators: the help text of an item in the application menubar
+#: bookworm/gui/book_viewer/menubar.py:591
+msgid "Go to page"
+msgstr "Va a la página"
+
+#. Translators: the label of an item in the application menubar
+#: bookworm/gui/book_viewer/menubar.py:596
+msgid "&Go To Page By Label...\tCtrl-Shift-G"
+msgstr "Ir a página por e&tiqueta...\tCtrl-Shift-G"
+
+#. Translators: the help text of an item in the application menubar
+#: bookworm/gui/book_viewer/menubar.py:598
+msgid "Go to a page using its label"
+msgstr "Va a una página utilizando su etiqueta"
+
+#: bookworm/gui/book_viewer/menubar.py:631
+msgid ""
+"You are here: {current_line}\n"
+"You can't go further than: {last_line}"
+msgstr ""
+"Estás aquí: {current_line}\n"
+"No puedes ir más allá de: {last_line}"
+
 #: bookworm/gui/book_viewer/menubar.py:634
-msgid "View Bookworm manuals"
-msgstr "Abre el manual de usuario para Bookworm"
+msgid "Line number"
+msgstr "Número de línea"
+
+#: bookworm/gui/book_viewer/menubar.py:635
+msgid "Jump to line"
+msgstr "Saltar a línea"
+
+#. Translators: the title of the go to page dialog
+#: bookworm/gui/book_viewer/menubar.py:648
+msgid "Go To Page"
+msgstr "Ir a Página"
+
+#: bookworm/gui/book_viewer/menubar.py:655
+msgid "Go To Page By Label"
+msgstr "Ir a página por Etiqueta"
+
+#: bookworm/gui/book_viewer/menubar.py:655
+msgid "Page Label"
+msgstr "Etiqueta de Página"
+
+#. Translators: the title of the search dialog
+#: bookworm/gui/book_viewer/menubar.py:663
+msgid "Search Document"
+msgstr "Buscar Documento"
+
+#: bookworm/gui/book_viewer/menubar.py:689
+msgid "Searching For '{term}'"
+msgstr "Buscando por '{term}'"
+
+#. Translators: message to announce the number of search results
+#. also used as the final title of the search results dialog
+#: bookworm/gui/book_viewer/menubar.py:704
+msgid "Results | {total}"
+msgstr "Resultados | {total}"
+
+#: bookworm/gui/book_viewer/menubar.py:741
+msgid "Search Result"
+msgstr "Buscar Documento"
 
 #. Translators: the label of an item in the application menubar
-#: bookworm/gui/book_viewer/menubar.py:639
-msgid "Bookworm &website..."
-msgstr "Sitio web de  &Bookworm..."
+#: bookworm/gui/book_viewer/menubar.py:779
+msgid "&User guide...\tF1"
+msgstr "&Guía de usuario...\tF1"
 
 #. Translators: the help text of an item in the application menubar
-#: bookworm/gui/book_viewer/menubar.py:641
-msgid "Visit the official website of Bookworm"
-msgstr "Visita el sitio oficial de Bookworm"
+#: bookworm/gui/book_viewer/menubar.py:781
+msgid "View Bookworm manuals"
+msgstr "Ver manuales de Bookworm"
 
 #. Translators: the label of an item in the application menubar
-#: bookworm/gui/book_viewer/menubar.py:646
+#: bookworm/gui/book_viewer/menubar.py:786
+msgid "Bookworm &website..."
+msgstr "Sitio &Web de Bookworm..."
+
+#. Translators: the help text of an item in the application menubar
+#: bookworm/gui/book_viewer/menubar.py:788
+msgid "Visit the official website of Bookworm"
+msgstr "Visita el sitio web oficial de Bookworm"
+
+#. Translators: the label of an item in the application menubar
+#: bookworm/gui/book_viewer/menubar.py:793
 msgid "&License"
 msgstr "&Licencia"
 
 #. Translators: the help text of an item in the application menubar
-#: bookworm/gui/book_viewer/menubar.py:648
+#: bookworm/gui/book_viewer/menubar.py:795
 msgid "View legal information about this program ."
-msgstr "Abre la información legal sobre este programa"
+msgstr "Ver información legal acerca de este programa."
 
 #. Translators: the label of an item in the application menubar
-#: bookworm/gui/book_viewer/menubar.py:653
+#: bookworm/gui/book_viewer/menubar.py:800
 msgid "Con&tributors"
-msgstr "Ayudantes"
+msgstr "&Contribuyentes"
 
 #. Translators: the help text of an item in the application menubar
-#: bookworm/gui/book_viewer/menubar.py:655
+#: bookworm/gui/book_viewer/menubar.py:802
 msgid "View a list of notable contributors to the program."
-msgstr "Abre una lista con los ayudantes destacables del programa."
+msgstr "Ver una lista de contribuyentes notables con el programa."
 
 #. Translators: the label of an item in the application menubar
-#: bookworm/gui/book_viewer/menubar.py:661
+#: bookworm/gui/book_viewer/menubar.py:808
 msgid "&Restart with debug-mode enabled"
-msgstr "&Reiniciar en modo de depuración"
+msgstr "&Reiniciar con modo depuración habilitado"
 
 #. Translators: the help text of an item in the application menubar
-#: bookworm/gui/book_viewer/menubar.py:663
+#: bookworm/gui/book_viewer/menubar.py:810
 msgid "Restart the program with debug mode enabled to show errors"
-msgstr "Reinicia el programa en modo de depuración para encontrar errores"
+msgstr ""
+"Reinicia el programa con modo depuración habilitado para mostrar errores"
 
 #. Translators: the label of an item in the application menubar
-#: bookworm/gui/book_viewer/menubar.py:673
+#: bookworm/gui/book_viewer/menubar.py:820
 msgid "&About Bookworm"
 msgstr "&Acerca de Bookworm"
 
 #. Translators: the help text of an item in the application menubar
-#: bookworm/gui/book_viewer/menubar.py:675
+#: bookworm/gui/book_viewer/menubar.py:822
 msgid "Show general information about this program"
-msgstr "Muestra información acerca del programa."
+msgstr "Muestra información general acerca de este programa"
 
 #. Translators: the title of the about dialog
-#: bookworm/gui/book_viewer/menubar.py:706
+#: bookworm/gui/book_viewer/menubar.py:855
 msgid "About {app_name}"
 msgstr "Acerca de {app_name}"
 
 #. Translators: the label of an item in the application menubar
-#: bookworm/gui/book_viewer/menubar.py:738
-msgid "&File"
-msgstr "&Archivo"
-
-#. Translators: the label of an item in the application menubar
-#: bookworm/gui/book_viewer/menubar.py:740
+#: bookworm/gui/book_viewer/menubar.py:891
 msgid "&Search"
-msgstr ""
+msgstr "&Buscar"
 
 #. Translators: the label of an item in the application menubar
-#: bookworm/gui/book_viewer/menubar.py:742
-msgid "&Tools"
-msgstr "&Herramientas"
+#: bookworm/gui/book_viewer/menubar.py:893
+msgid "&Document"
+msgstr "&Documento"
 
 #. Translators: the label of an item in the application menubar
-#: bookworm/gui/book_viewer/menubar.py:744
+#: bookworm/gui/book_viewer/menubar.py:895
 msgid "&Help"
-msgstr "&Ayuda"
+msgstr "A&yuda"
 
-#: bookworm/gui/book_viewer/menubar.py:773
+#: bookworm/gui/book_viewer/menubar.py:938
 msgid "Jump to a page"
-msgstr ""
+msgstr "Saltar a una página"
 
-#: bookworm/gui/book_viewer/menubar.py:821
-#, fuzzy
+#: bookworm/gui/book_viewer/menubar.py:992
 msgid "Supported document formats"
-msgstr "Documento de archivo no soportado"
+msgstr "Formatos de documento admitidos"
 
-#: bookworm/gui/book_viewer/render_view.py:112
+#: bookworm/gui/book_viewer/render_view.py:88
 msgid "Zoom is at {factor} percent"
-msgstr "El zoom está en  {factor} por ciento"
+msgstr "El Zoom está en un {factor} porciento"
 
-#: bookworm/gui/book_viewer/render_view.py:124
+#: bookworm/gui/book_viewer/render_view.py:100
 msgid "Page {}"
-msgstr ""
+msgstr "Página {}"
 
 #. Translators: content of a message in a progress dialog
-#: bookworm/http_tools/http_resource.py:41
-#, fuzzy
+#: bookworm/http_tools/http_resource.py:43
+#: bookworm/platforms/win32/updater.py:195
 msgid "Downloaded {downloaded} MB of {total} MB"
-msgstr "Descargando. {downloaded} MB of {total} MB"
+msgstr "Descargado {downloaded} MB de {total} MB"
 
 #. Translators: the label of a page in the settings dialog
-#. Translators: the label of the OCR menu in the application menubar
-#: bookworm/ocr/__init__.py:54 bookworm/ocr/__init__.py:58
-#: bookworm/ocr/ocr_menu.py:107
+#. Translators: the label of an item in the application menubar
+#: bookworm/ocr/__init__.py:75 bookworm/ocr/__init__.py:94
+#: bookworm/ocr/__init__.py:97
 msgid "OCR"
-msgstr ""
+msgstr "OCR"
 
 #. Translators: the label of a group of controls in the reading page
-#: bookworm/ocr/ocr_dialogs.py:63 bookworm/ocr/ocr_menu.py:162
+#: bookworm/ocr/ocr_dialogs.py:63 bookworm/ocr/ocr_menu.py:209
 msgid "OCR Options"
-msgstr ""
+msgstr "Opciones de OCR"
 
 #. Translators: the title of a group of radio buttons in the OCR page
 #. in the application settings.
-#: bookworm/ocr/ocr_dialogs.py:69
+#: bookworm/ocr/ocr_dialogs.py:70
 msgid "Default OCR Engine"
-msgstr ""
+msgstr "Motor OCR predeterminado"
 
 #. Translators: the label of a group of controls in the OCR page
 #. of the settings related to Tesseract OCR engine
-#: bookworm/ocr/ocr_dialogs.py:76
-#: bookworm/ocr_engines/tesseract_ocr_engine/__init__.py:28
+#: bookworm/ocr/ocr_dialogs.py:77
+#: bookworm/ocr_engines/tesseract_ocr_engine/__init__.py:25
+#: bookworm/ocr_engines/tesseract_ocr_engine/alt_tess.py:29
 msgid "Tesseract OCR Engine"
-msgstr ""
-
-#: bookworm/ocr/ocr_dialogs.py:81
-msgid "Download Tesseract OCR Engine"
-msgstr ""
+msgstr "Motor Tesseract OCR"
 
 #: bookworm/ocr/ocr_dialogs.py:82
+msgid "Download Tesseract OCR Engine"
+msgstr "Descargar el Motor Tesseract OCR"
+
+#: bookworm/ocr/ocr_dialogs.py:83
 msgid "Get a free, high-quality OCR engine that supports over 100 languages."
 msgstr ""
+"Obtiene un motor OCR libre y de alta calidad que admite sobre 100 idiomas."
 
-#: bookworm/ocr/ocr_dialogs.py:91
+#. Translators: label of a button
+#: bookworm/ocr/ocr_dialogs.py:93
 msgid "Manage Tesseract OCR Languages"
-msgstr ""
+msgstr "Administrar Idiomas de Tesseract OCR"
 
-#: bookworm/ocr/ocr_dialogs.py:92
+#. Translators: description of a button
+#: bookworm/ocr/ocr_dialogs.py:95
 msgid "Add support for new languages, and /or remove installed languages."
-msgstr ""
+msgstr "Añade soporte para nuevos idiomas y/o elimina los idiomas instalados."
+
+#. Translators: label of a button
+#: bookworm/ocr/ocr_dialogs.py:101
+msgid "Update Tesseract OCr Engine"
+msgstr "Actualizar el Motor Tesseract OCR"
+
+#. Translators: description of a button
+#: bookworm/ocr/ocr_dialogs.py:103
+msgid "Check for and install updates for Tesseract OCR Engine"
+msgstr "Comprueba e instala actualizaciones para el Motor Tesseract OCR"
 
 #. Translators: the label of a group of controls in the reading page
 #. of the settings related to image enhancement
-#: bookworm/ocr/ocr_dialogs.py:97
+#: bookworm/ocr/ocr_dialogs.py:109
 msgid "Image processing"
-msgstr ""
+msgstr "Procesamiento de Imagen"
 
 #. Translators: the label of a checkbox
-#: bookworm/ocr/ocr_dialogs.py:102
+#: bookworm/ocr/ocr_dialogs.py:115
 msgid "Enable default image enhancement filters"
-msgstr ""
-
-#: bookworm/ocr/ocr_dialogs.py:124
-msgid "Retrieving download info, please wait..."
-msgstr ""
-
-#: bookworm/ocr/ocr_dialogs.py:130
-msgid "Manage Tesseract OCR Engine Languages"
-msgstr ""
+msgstr "Habilita los filtros predeterminados de mejora de imagen"
 
 #. Translators: title of a progress dialog
-#: bookworm/ocr/ocr_dialogs.py:144
+#: bookworm/ocr/ocr_dialogs.py:139
 msgid "Downloading Tesseract OCR Engine"
-msgstr ""
+msgstr "Descargando el Motor Tesseract OCR"
 
-#. Translators: message of a progress dialog
-#. Translators: content of a progress dialog
-#: bookworm/ocr/ocr_dialogs.py:146 bookworm/ocr/ocr_dialogs.py:465
-msgid "Getting download information..."
-msgstr ""
+#. Translators: title of a dialog to manage Tesseract OCR engine languages
+#: bookworm/ocr/ocr_dialogs.py:152
+msgid "Manage Tesseract OCR Engine Languages"
+msgstr "Administrar Idiomas del Motor Tesseract OCR"
 
-#: bookworm/ocr/ocr_dialogs.py:158
-msgid "Restart Required"
-msgstr ""
-
-#: bookworm/ocr/ocr_dialogs.py:159
+#. Translators: content of a message box
+#: bookworm/ocr/ocr_dialogs.py:163
 msgid ""
-"Bookworm will now restart to complete the installation of the Tesseract "
-"OCR Engine."
+"Bookworm will now restart to complete the installation of the Tesseract OCR "
+"Engine."
 msgstr ""
+"Bookworm ahora se reiniciará para completar la instalación del Motor "
+"Tesseract OCR."
+
+#. Translators: content of a message box
+#: bookworm/ocr/ocr_dialogs.py:183
+msgid ""
+"A new version of Tesseract OCr engine is available for download.\n"
+"It is strongly recommended to update to the latest version for the best "
+"accuracy and performance.\n"
+"Would you like to update to the new version?"
+msgstr ""
+"Está disponible una nueva versión del Motor Tesseract OCR para descargar.\n"
+"Se recomienda encarecidamente actualizar a la última versión para obtener la "
+"máxima precisión y rendimiento.\n"
+"¿Te gustaría actualizar a la nueva versión?"
+
+#. Translators: title of a message box
+#: bookworm/ocr/ocr_dialogs.py:187
+msgid "Update Tesseract OCr Engine?"
+msgstr "¿Actualizar el Motor Tesseract OCR?"
+
+#. Translators: message of a dialog
+#: bookworm/ocr/ocr_dialogs.py:196
+msgid "Removing old Tesseract version. Please wait..."
+msgstr "Eliminando versiones antiguas de Tesseract. Por favor espera..."
+
+#. Translators: content of a message box
+#: bookworm/ocr/ocr_dialogs.py:202
+msgid "Your version of Tesseract OCR engine is up to date."
+msgstr "Tu versión del Motor Tesseract OCR está actualizada."
+
+#. Translators: content of a message box
+#: bookworm/ocr/ocr_dialogs.py:213
+msgid "Failed to check for updates for Tesseract OCr engine."
+msgstr "Falló al comprobar las actualizaciones para el Motor Tesseract OCr."
+
+#. Translators: title of a group of controls
+#: bookworm/ocr/ocr_dialogs.py:247
+msgid "Recognition Language"
+msgstr "Idioma de Reconocimiento"
 
 #. Translators: the label of a combobox
-#: bookworm/ocr/ocr_dialogs.py:186
-msgid "Recognition Language:"
-msgstr ""
+#: bookworm/ocr/ocr_dialogs.py:249
+msgid "Primary recognition Language"
+msgstr "Idioma de Reconocimiento Principal"
 
-#: bookworm/ocr/ocr_dialogs.py:191
-msgid "Supplied Image resolution::"
-msgstr ""
+#: bookworm/ocr/ocr_dialogs.py:256
+msgid "Add a secondary recognition language"
+msgstr "Añade un idioma de reconocimiento secundario"
 
-#: bookworm/ocr/ocr_dialogs.py:195
-msgid "Enable image enhancements"
-msgstr ""
-
-#: bookworm/ocr/ocr_dialogs.py:200
-msgid "Available image pre-processing filters:"
-msgstr ""
-
-#. Translators: the label of a checkbox
-#: bookworm/ocr/ocr_dialogs.py:215
-msgid "&Save these options until I close the current book"
-msgstr ""
-
-#: bookworm/ocr/ocr_dialogs.py:264
-msgid "Increase image resolution"
-msgstr ""
-
-#: bookworm/ocr/ocr_dialogs.py:265
-msgid "Binarization"
-msgstr ""
+#: bookworm/ocr/ocr_dialogs.py:260
+msgid "Secondary recognition Language"
+msgstr "Idioma Secundario de Reconocimiento"
 
 #: bookworm/ocr/ocr_dialogs.py:268
-msgid "Split two-in-one scans to individual pages"
-msgstr ""
+#: bookworm/structured_text/structural_elements.py:71
+msgid "Image"
+msgstr "Imagen"
 
-#: bookworm/ocr/ocr_dialogs.py:271
-msgid "Combine images"
-msgstr ""
-
-#: bookworm/ocr/ocr_dialogs.py:272
-msgid "Blurring"
-msgstr ""
+#: bookworm/ocr/ocr_dialogs.py:269
+msgid "Supplied Image resolution::"
+msgstr "Resolución de imagen suministrada::"
 
 #: bookworm/ocr/ocr_dialogs.py:273
+msgid "Enable image enhancements"
+msgstr "Habilitar mejoras de imagen"
+
+#: bookworm/ocr/ocr_dialogs.py:278
+msgid "Available image pre-processing filters:"
+msgstr "Filtros de preprocesamiento de imágenes disponibles:"
+
+#. Translators: the label of a checkbox
+#: bookworm/ocr/ocr_dialogs.py:293
+msgid "&Save these options until I close the current book"
+msgstr "&Guardar estas opciones hasta que cierre el libro actual"
+
+#: bookworm/ocr/ocr_dialogs.py:374
+msgid "Increase image resolution"
+msgstr "Aumentar la resolución de la imagen"
+
+#: bookworm/ocr/ocr_dialogs.py:375
+msgid "Binarization"
+msgstr "Binarización"
+
+#: bookworm/ocr/ocr_dialogs.py:378
+msgid "Split two-in-one scans to individual pages"
+msgstr "Dividir escaneados dos en uno en páginas individuales"
+
+#: bookworm/ocr/ocr_dialogs.py:381
+msgid "Combine images"
+msgstr "Combinar imágenes"
+
+#: bookworm/ocr/ocr_dialogs.py:382
+msgid "Blurring"
+msgstr "Difuminar"
+
+#: bookworm/ocr/ocr_dialogs.py:383
 msgid "Deskewing"
-msgstr ""
+msgstr "Descortezar"
 
-#: bookworm/ocr/ocr_dialogs.py:274
+#: bookworm/ocr/ocr_dialogs.py:384
 msgid "Erosion"
-msgstr ""
+msgstr "Erosionar"
 
-#: bookworm/ocr/ocr_dialogs.py:275
+#: bookworm/ocr/ocr_dialogs.py:385
 msgid "Dilation"
-msgstr ""
+msgstr "Dilatar"
 
-#: bookworm/ocr/ocr_dialogs.py:276
+#: bookworm/ocr/ocr_dialogs.py:386
 msgid "Sharpen image"
-msgstr ""
+msgstr "Enfocar imagen"
 
-#: bookworm/ocr/ocr_dialogs.py:277
+#: bookworm/ocr/ocr_dialogs.py:387
 msgid "Invert colors"
-msgstr ""
+msgstr "Invertir colores"
 
-#: bookworm/ocr/ocr_dialogs.py:280
+#: bookworm/ocr/ocr_dialogs.py:390
 msgid "Debug"
-msgstr ""
+msgstr "Depurar"
+
+#: bookworm/ocr/ocr_dialogs.py:409
+msgid "Installed Languages"
+msgstr "Idiomas Instalados"
+
+#: bookworm/ocr/ocr_dialogs.py:413
+msgid "Downloadable Languages"
+msgstr "Idiomas Descargables"
 
 #. Translators: label of a list control containing bookmarks
-#: bookworm/ocr/ocr_dialogs.py:298
+#: bookworm/ocr/ocr_dialogs.py:444
 msgid "Tesseract Languages"
-msgstr ""
+msgstr "Idiomas de Tesseract"
 
-#. Translators: text of a button to add a language to Tesseract OCR Engine
-#. (best quality model)
-#: bookworm/ocr/ocr_dialogs.py:309
+#: bookworm/ocr/ocr_dialogs.py:457
 msgid "Download &Best Model"
-msgstr ""
+msgstr "Descargar el &Mejor Modelo"
 
-#. Translators: text of a button to add a language to Tesseract OCR Engine
-#. (fastest model)
-#: bookworm/ocr/ocr_dialogs.py:311
+#: bookworm/ocr/ocr_dialogs.py:461
 msgid "Download &Fast Model"
-msgstr ""
-
-#: bookworm/ocr/ocr_dialogs.py:325 bookworm/ocr/ocr_dialogs.py:399
-msgid "Getting download information, please wait..."
-msgstr ""
+msgstr "Descargar el Modelo más &Rápido"
 
 #. Translators: the title of a column in the Tesseract language list
-#: bookworm/ocr/ocr_dialogs.py:367
-#, fuzzy
-msgid "Language"
-msgstr "Idioma para mostrar:"
-
-#. Translators: the title of a column in the Tesseract language list
-#: bookworm/ocr/ocr_dialogs.py:374
+#: bookworm/ocr/ocr_dialogs.py:503
 msgid "Installed"
-msgstr ""
+msgstr "Instalado"
 
-#: bookworm/ocr/ocr_dialogs.py:377
+#: bookworm/ocr/ocr_dialogs.py:506
 msgid "Yes"
-msgstr ""
+msgstr "Sí"
 
-#: bookworm/ocr/ocr_dialogs.py:377
+#: bookworm/ocr/ocr_dialogs.py:506
 msgid "No"
-msgstr ""
+msgstr "No"
 
 #. Translators: content of a messagebox
-#: bookworm/ocr/ocr_dialogs.py:409
+#: bookworm/ocr/ocr_dialogs.py:536
+msgid ""
+"A version of the selected language model already exists.\n"
+"Are you sure you want to replace it?"
+msgstr ""
+"Ya existe una versión del modelo de idioma seleccionado.\n"
+"¿Estás seguro de que deseas sustituirla?"
+
+#. Translators: title of a progress dialog
+#: bookworm/ocr/ocr_dialogs.py:554
+msgid "Downloading Language"
+msgstr "Descargando Idioma"
+
+#. Translators: content of a messagebox
+#: bookworm/ocr/ocr_dialogs.py:579
 msgid ""
 "Are you sure you want to remove language:\n"
 "{lang}?"
 msgstr ""
-
-#. Translators: content of a messagebox
-#: bookworm/ocr/ocr_dialogs.py:445
-msgid ""
-"A version of the selected language model already exists.\n"
-"Are you sure you want to replace it."
-msgstr ""
-
-#. Translators: title of a progress dialog
-#: bookworm/ocr/ocr_dialogs.py:463
-#, fuzzy
-msgid "Downloading Language"
-msgstr "Descargando Actualización"
+"¿estás seguro de que quieres eliminar el idioma:\n"
+"{lang}?"
 
 #. Translators: title of a messagebox
-#: bookworm/ocr/ocr_dialogs.py:485
-#, fuzzy
+#: bookworm/ocr/ocr_dialogs.py:604
 msgid "Language Added"
-msgstr "Idioma cambiado"
+msgstr "Idioma Añadido"
 
-#: bookworm/ocr/ocr_dialogs.py:486
+#. Translators: content of a message box
+#: bookworm/ocr/ocr_dialogs.py:606
 msgid "The Language Model was downloaded successfully."
-msgstr ""
+msgstr "El modelo lingüístico se ha descargado correctamente."
 
+#. Translators: title of a message box
 #. Translators: title of a messagebox
-#: bookworm/ocr/ocr_dialogs.py:494 bookworm/webservices/wikiworm.py:107
+#: bookworm/ocr/ocr_dialogs.py:614
+#: bookworm/platforms/win32/pandoc_download.py:54
+#: bookworm/platforms/win32/tesseract_download.py:85
+#: bookworm/webservices/wikiworm.py:135
 msgid "Connection Error"
-msgstr ""
+msgstr "Error de Conexión"
 
-#. Translators: content of a messagebox
-#: bookworm/ocr/ocr_dialogs.py:496
+#. Translators: content of a message box
+#: bookworm/ocr/ocr_dialogs.py:616
 msgid ""
 "Failed to download language data.\n"
 "Please check your internet connection."
 msgstr ""
-
-#. Translators: title of a messagebox
-#. Translators: the title of a message telling the user that an error has
-#. occurred
-#: bookworm/ocr/ocr_dialogs.py:505 bookworm/text_to_speech/tts_gui.py:426
-#: bookworm/webservices/wikiworm.py:117
-msgid "Error"
-msgstr "Error"
+"No se han podido descargar los datos del idioma.\n"
+"Comprueba tu conexión a Internet."
 
 #. Translators: content of a messagebox
-#: bookworm/ocr/ocr_dialogs.py:507
+#: bookworm/ocr/ocr_dialogs.py:627
 msgid ""
 "Failed to install language data.\n"
 "Please try again later."
 msgstr ""
+"No se han podido instalar los datos de idioma.\n"
+"Vuelve a intentarlo más tarde."
+
+#: bookworm/ocr/ocr_menu.py:86
+msgid "Recognition Result: {image_name}"
+msgstr "Resultado de Reconocimiento: {image_name}"
 
 #. Translators: the label of an item in the application menubar
-#: bookworm/ocr/ocr_menu.py:72
-#, fuzzy
+#: bookworm/ocr/ocr_menu.py:121
 msgid "&Scan Current Page...\tF4"
-msgstr "Leer la página actual"
+msgstr "&Escanear Página Actual...\tF4"
 
 #. Translators: the help text of an item in the application menubar
-#: bookworm/ocr/ocr_menu.py:74
-#, fuzzy
+#: bookworm/ocr/ocr_menu.py:123
 msgid "Run OCR on the current page"
-msgstr "Leer la página actual"
+msgstr "Ejecuta el OCR en la página actual"
 
 #. Translators: the label of an item in the application menubar
-#: bookworm/ocr/ocr_menu.py:79
+#: bookworm/ocr/ocr_menu.py:128
 msgid "&Automatic OCR\tCtrl-F4"
-msgstr ""
+msgstr "OCR &Automático\tCtrl-F4"
 
 #. Translators: the help text of an item in the application menubar
-#: bookworm/ocr/ocr_menu.py:81
+#: bookworm/ocr/ocr_menu.py:130
 msgid "Auto run  OCR when turning pages."
-msgstr ""
+msgstr "Ejecuta automáticamente el OCR al pasar las páginas."
 
 #. Translators: the label of an item in the application menubar
-#: bookworm/ocr/ocr_menu.py:87
+#: bookworm/ocr/ocr_menu.py:136
 msgid "&Change OCR Options..."
-msgstr ""
+msgstr "&Cambiar Opciones del OCR..."
 
 #. Translators: the help text of an item in the application menubar
-#: bookworm/ocr/ocr_menu.py:89
+#: bookworm/ocr/ocr_menu.py:138
 msgid "Change OCR options"
-msgstr ""
+msgstr "Cambia las ocpiones del OCR"
 
 #. Translators: the label of an item in the application menubar
-#: bookworm/ocr/ocr_menu.py:94
+#: bookworm/ocr/ocr_menu.py:143
 msgid "Scan To &Text File..."
-msgstr ""
+msgstr "Escanear a Fichero de &Texto..."
 
 #. Translators: the help text of an item in the application menubar
-#: bookworm/ocr/ocr_menu.py:96
+#: bookworm/ocr/ocr_menu.py:145
 msgid "Scan pages and save the text to a .txt file."
-msgstr ""
+msgstr "Escanea páginas y las guarda en un fichero .txt."
 
 #. Translators: the label of an item in the application menubar
-#: bookworm/ocr/ocr_menu.py:101
+#: bookworm/ocr/ocr_menu.py:150
 msgid "Image To Text..."
-msgstr ""
+msgstr "Imagen a Texto..."
 
 #. Translators: the help text of an item in the application menubar
-#: bookworm/ocr/ocr_menu.py:103
-msgid "Run OCR on an image."
-msgstr ""
-
-#. Translators: content of a message
 #: bookworm/ocr/ocr_menu.py:152
+msgid "Run OCR on an image."
+msgstr "Ejecuta el OCR en una imagen."
+
+#. Translators: the label of the OCR menu in the application menubar
+#. Event handlers
+#. Translators: content of a message
+#: bookworm/ocr/ocr_menu.py:199
 msgid ""
 "No language for OCR is present.\n"
 "Please checkout Bookworm user manual to learn how to add new languages."
 msgstr ""
+"No hay ningún idioma para el OCR.\n"
+"Consulta el manual de usuario de Bookworm para aprender a añadir nuevos "
+"idiomas."
 
 #. Translators: title for a message
-#: bookworm/ocr/ocr_menu.py:156
+#: bookworm/ocr/ocr_menu.py:203
 msgid "No Languages for OCR"
-msgstr ""
+msgstr "No hay Idiomas para el OCR"
 
-#: bookworm/ocr/ocr_menu.py:174
-#, fuzzy
+#: bookworm/ocr/ocr_menu.py:222
 msgid "Canceled"
-msgstr "Cancelar"
+msgstr "Cancelado"
 
-#: bookworm/ocr/ocr_menu.py:210
-#, fuzzy
+#: bookworm/ocr/ocr_menu.py:258
 msgid "Running OCR, please wait..."
-msgstr "Por favor espere..."
+msgstr "Ejecutando el OCR, por favor espera..."
 
-#: bookworm/ocr/ocr_menu.py:219
+#: bookworm/ocr/ocr_menu.py:268
 msgid "Automatic OCR is enabled"
-msgstr ""
+msgstr "El OCR automático está habilitado"
 
-#: bookworm/ocr/ocr_menu.py:221
+#: bookworm/ocr/ocr_menu.py:270
 msgid "Automatic OCR is disabled"
-msgstr ""
+msgstr "El OCR automático está deshabilitado"
 
 #. Translators: the title of a save file dialog asking the user for a filename
 #. to export notes to
-#: bookworm/ocr/ocr_menu.py:234
+#: bookworm/ocr/ocr_menu.py:283
 msgid "Save as"
-msgstr ""
+msgstr "Guardar como"
 
 #. Translators: the title of a progress dialog
-#: bookworm/ocr/ocr_menu.py:251
+#: bookworm/ocr/ocr_menu.py:300
 msgid "Scanning Pages"
-msgstr ""
+msgstr "Escaneando Páginas"
 
 #. Translators: the message of a progress dialog
-#: bookworm/ocr/ocr_menu.py:253
+#: bookworm/ocr/ocr_menu.py:302
 msgid "Preparing book"
-msgstr ""
+msgstr "Preparando libro"
 
-#: bookworm/ocr/ocr_menu.py:272
+#: bookworm/ocr/ocr_menu.py:327
 msgid ""
 "Successfully processed {total} pages.\n"
 "Extracted text was written to: {file}"
 msgstr ""
+"Procesadas con éxito {total} páginas.\n"
+"El texto extraído se escribió en: {file}"
 
-#: bookworm/ocr/ocr_menu.py:275
+#: bookworm/ocr/ocr_menu.py:330
 msgid "OCR Completed"
-msgstr ""
+msgstr "OCR Completado"
 
-#: bookworm/ocr/ocr_menu.py:292
+#: bookworm/ocr/ocr_menu.py:344
 msgid "Portable Network Graphics"
-msgstr ""
+msgstr "Gráficos de red portables"
 
-#: bookworm/ocr/ocr_menu.py:293
+#: bookworm/ocr/ocr_menu.py:345
 msgid "JPEG images"
-msgstr ""
+msgstr "Imágenes JPEG"
 
-#: bookworm/ocr/ocr_menu.py:294
+#: bookworm/ocr/ocr_menu.py:346
 msgid "Bitmap images"
-msgstr ""
+msgstr "Imágenes Bitmap"
 
-#: bookworm/ocr/ocr_menu.py:295
+#: bookworm/ocr/ocr_menu.py:347
 msgid "Tiff graphics"
-msgstr ""
+msgstr "Gráficos Tiff"
 
-#: bookworm/ocr/ocr_menu.py:301
-#, fuzzy
+#: bookworm/ocr/ocr_menu.py:353
 msgid "All supported image formats"
-msgstr "Documento de archivo no soportado"
+msgstr "Todos los formatos de imágenes admitidos"
 
 #. Translators: the title of a file dialog to browse to an image
-#: bookworm/ocr/ocr_menu.py:305
+#: bookworm/ocr/ocr_menu.py:357
 msgid "Choose image file"
-msgstr ""
+msgstr "Elige ficheros de imágenes"
 
 #. Translators: content of a message box
-#: bookworm/ocr/ocr_menu.py:320
+#: bookworm/ocr/ocr_menu.py:372
 msgid ""
 "Could not load image from\n"
 "{filename}.\n"
-"Please make sure the file exists and the data contained in is not "
-"corrupted."
+"Please make sure the file exists and the data contained in is not corrupted."
 msgstr ""
+"No se pudo cargar la imagen de\n"
+"{filename}.\n"
+"Por favor asegúrate de que el fichero exista y de que los datos contenidos "
+"en él no estén corrompidos."
 
 #. Translators: title of a message box
-#: bookworm/ocr/ocr_menu.py:325
+#: bookworm/ocr/ocr_menu.py:377
 msgid "Could not load image file"
-msgstr ""
+msgstr "No se pudo cargar el fichero de imágenes"
 
-#: bookworm/ocr/ocr_menu.py:339
-msgid "OCR Results"
-msgstr ""
-
-#: bookworm/ocr/ocr_menu.py:366
+#: bookworm/ocr/ocr_menu.py:423
 msgid "Scan finished."
-msgstr ""
+msgstr "Escaneado finalizado."
 
-#: bookworm/ocr/ocr_menu.py:372
+#: bookworm/ocr/ocr_menu.py:429
 msgid "OCR canceled"
-msgstr ""
+msgstr "OCR cancelado"
 
-#: bookworm/ocr_engines/tesseract_ocr_engine/tesseract_alt.py:20
-msgid "Tesseract OCR Engine (Alternative implementation)"
+#. Translators: the content of a message indicating the availability of an
+#. update
+#: bookworm/platforms/linux/updater.py:14
+msgid ""
+"A new update for Bookworm is available.\n"
+"\tInstalled Version: {current}\n"
+"\tNew Version: {new}\n"
+"Please check Bookworm's documentation to learn how to update your version of "
+"Bookworm"
 msgstr ""
+"Está disponible una nueva actualización de Bookworm.\n"
+"\tLa Versión Instalada Es: {current}\n"
+"\tLa Nueva Versión Es: {new}\n"
+"Por favor consulta la documentación de Bookworm para saber cómo actualizar "
+"tu versión de Bookworm"
+
+#. Translators: the title of a message indicating the availability of an update
+#: bookworm/platforms/linux/updater.py:22
+msgid "Update Available"
+msgstr "Actualización Disponible"
+
+#: bookworm/platforms/win32/docr_engine.py:28
+msgid "Windows 10 OCR"
+msgstr "OCR de Windows 10"
+
+#: bookworm/platforms/win32/pandoc_download.py:39
+#: bookworm/platforms/win32/tesseract_download.py:70
+msgid "Extracting file..."
+msgstr "Extrayendo Archivo..."
+
+#. Translators: content of a messagebox
+#: bookworm/platforms/win32/pandoc_download.py:47
+msgid "Pandoc downloaded successfully"
+msgstr "Pandoc descargado correctamente"
+
+#: bookworm/platforms/win32/pandoc_download.py:55
+msgid ""
+"Could not download Pandoc.\n"
+"Please check your internet connection and try again."
+msgstr ""
+"No se ha podido descargar Pandoc.\n"
+"Por favor comprueba tu conexión a internet e inténtalo de nuevo."
+
+#: bookworm/platforms/win32/pandoc_download.py:64
+msgid ""
+"Could not add Pandoc.\n"
+"Please try again."
+msgstr ""
+"No se ha podido añadir Pandoc.\n"
+"Por favor inténtalo de nuevo."
+
+#. Translators: content of a messagebox
+#: bookworm/platforms/win32/tesseract_download.py:78
+msgid "Tesseract engine downloaded successfully"
+msgstr "Motor Tesseract descargado correctamente"
+
+#: bookworm/platforms/win32/tesseract_download.py:86
+msgid ""
+"Could not download Tesseract OCR Engine.\n"
+"Please check your internet and try again."
+msgstr ""
+"No se ha podido descargar el Motor OCR Tesseract.\n"
+"Por favor comprueba tu internet e inténtalo de nuevo."
+
+#: bookworm/platforms/win32/tesseract_download.py:97
+msgid ""
+"Could not install the Tesseract OCR engine.\n"
+"Please try again."
+msgstr ""
+"No se ha podido instalar el Motor OCR Tesseract.\n"
+"Por favor inténtalo de nuevo."
+
+#. Translators: the content of a message indicating the availability of an
+#. update
+#: bookworm/platforms/win32/updater.py:74
+msgid ""
+"A new update for Bookworm has been released.\n"
+"Would you like to download and install it?\n"
+"Installed Version: {current}\n"
+"New Version: {new}\n"
+msgstr ""
+"Se ha publicado una nueva actualización de Bookworm.\n"
+"¿Te gustaría descargarla e instalarla?\n"
+"La Versión instalada es: {current}\n"
+"La versión nueva es: {new}\n"
+
+#. Translators: the title of a message indicating the availability of an update
+#: bookworm/platforms/win32/updater.py:81
+msgid "Bookworm Update"
+msgstr "Actualizar Bookworm"
+
+#. Translators: the title of a message indicating the progress of downloading
+#. an update
+#: bookworm/platforms/win32/updater.py:91
+msgid "Downloading Update"
+msgstr "Descargando la Actualización"
+
+#. Translators: a message indicating the progress of downloading an update
+#. bundle
+#: bookworm/platforms/win32/updater.py:93
+msgid "Downloading update bundle"
+msgstr "Descargando el paquete de actualización"
+
+#. Translators: the content of a message indicating a failure in downloading an
+#. update
+#: bookworm/platforms/win32/updater.py:113
+msgid ""
+"A network error was occured when trying to download the update.\n"
+"Make sure you are connected to the internet, or try again at a later time."
+msgstr ""
+"Se ha producido un error de red al intentar descargar la actualización.\n"
+"Asegúrate de que estás conectado a Internet o inténtalo de nuevo más tarde."
+
+#. Translators: the content of a message indicating a corrupted file
+#: bookworm/platforms/win32/updater.py:133
+msgid ""
+"The update file has been downloaded, but it has been corrupted during "
+"download.\n"
+"Would you like to download the update file again?"
+msgstr ""
+"Se ha descargado el archivo de actualización, pero se ha dañado durante la "
+"descarga.\n"
+"Deseas volver a descargar el archivo de actualización?"
+
+#. Translators: the title of a message indicating a corrupted file
+#: bookworm/platforms/win32/updater.py:138
+msgid "Download Error"
+msgstr "Error en la Descarga"
+
+#: bookworm/platforms/win32/updater.py:149
+msgid "Extracting update bundle..."
+msgstr "Extrayendo paquete de actualización..."
+
+#: bookworm/platforms/win32/updater.py:154
+msgid ""
+"A problem has occured when installing the update.\n"
+"Please check the logs for more info."
+msgstr ""
+"Se ha producido un problema al instalar la actualización.\n"
+"Consulta los registros para obtener más información."
+
+#: bookworm/platforms/win32/updater.py:157
+msgid "Error installing update"
+msgstr "Error instalando actualización"
+
+#. Translators: the content of a message indicating successful download of the
+#. update bundle
+#: bookworm/platforms/win32/updater.py:166
+msgid ""
+"The update has been downloaded successfully, and it is ready to be "
+"installed.\n"
+"The application will be restarted in order to complete the update process.\n"
+"Click the OK button to continue."
+msgstr ""
+"La actualización se ha descargado correctamente y está lista para ser "
+"instalada.\n"
+"La aplicación se reiniciará para completar el proceso de actualización.\n"
+"Pulsa el botón Aceptar para continuar."
+
+#. Translators: the title of a message indicating successful download of the
+#. update bundle
+#: bookworm/platforms/win32/updater.py:172
+msgid "Download Completed"
+msgstr "Descarga Completada"
+
+#: bookworm/platforms/win32/speech_engines/onecore.py:73
+msgid "One-core Synthesizer"
+msgstr "Sintetizador One-core"
+
+#: bookworm/platforms/win32/speech_engines/espeak/__init__.py:74
+msgid "eSpeak NG"
+msgstr "eSpeak NG"
+
+#. Translators: name of the default espeak varient.
+#: bookworm/platforms/win32/speech_engines/espeak/_espeak.py:442
+msgctxt "espeakVarient"
+msgid "espeakVarient"
+msgstr "espeakVarient"
+
+#: bookworm/platforms/win32/speech_engines/piper/__init__.py:203
+msgid "Piper Neural TTS"
+msgstr "Piper Neural TTS"
 
 #: bookworm/speechdriver/__init__.py:16
 msgid "No Speech"
-msgstr ""
-
-#: bookworm/structured_text/structural_elements.py:58
-#, fuzzy
-msgid "Heading"
-msgstr "Lectura"
-
-#: bookworm/structured_text/structural_elements.py:59
-msgid "Heading level 1"
-msgstr ""
+msgstr "Sin voz"
 
 #: bookworm/structured_text/structural_elements.py:60
-msgid "Heading level 2"
-msgstr ""
+msgid "Heading"
+msgstr "Encabezado"
 
 #: bookworm/structured_text/structural_elements.py:61
-msgid "Heading level 3"
-msgstr ""
+msgid "Heading level 1"
+msgstr "Encabezado de nivel 1"
 
 #: bookworm/structured_text/structural_elements.py:62
-msgid "Heading level 4"
-msgstr ""
+msgid "Heading level 2"
+msgstr "Encabezado de nivel 2"
 
 #: bookworm/structured_text/structural_elements.py:63
-msgid "Heading level 5"
-msgstr ""
+msgid "Heading level 3"
+msgstr "Encabezado de nivel 3"
 
 #: bookworm/structured_text/structural_elements.py:64
-msgid "Heading level 6"
-msgstr ""
+msgid "Heading level 4"
+msgstr "Encabezado de nivel 4"
 
 #: bookworm/structured_text/structural_elements.py:65
-msgid "Anchor"
-msgstr ""
+msgid "Heading level 5"
+msgstr "Encabezado de nivel 5"
 
 #: bookworm/structured_text/structural_elements.py:66
-msgid "Link"
-msgstr ""
+msgid "Heading level 6"
+msgstr "Encabezado de nivel 6"
 
 #: bookworm/structured_text/structural_elements.py:67
-msgid "List"
-msgstr ""
+msgid "Link"
+msgstr "Enlace"
 
 #: bookworm/structured_text/structural_elements.py:68
-msgid "Quote"
-msgstr ""
+msgid "List"
+msgstr "Lista"
 
 #: bookworm/structured_text/structural_elements.py:69
-msgid "Table"
-msgstr ""
+msgid "Quote"
+msgstr "Cita"
 
 #: bookworm/structured_text/structural_elements.py:70
-#, fuzzy
-msgid "Image"
-msgstr "Página"
+msgid "Table"
+msgstr "Tabla"
+
+#. Translators: the label of an item in the application menubar
+#: bookworm/text_to_speech/__init__.py:106
+msgid "S&peech"
+msgstr "&Voz"
 
 #. Translators: the label of a page in the settings dialog
-#: bookworm/text_to_speech/__init__.py:114
+#: bookworm/text_to_speech/__init__.py:111
 msgid "Reading"
 msgstr "Lectura"
 
 #. Translators: the label of a page in the settings dialog
 #. Translators: the label of a group of controls in the
 #. speech settings page related to voice selection
-#: bookworm/text_to_speech/__init__.py:116
-#: bookworm/text_to_speech/__init__.py:127
-#: bookworm/text_to_speech/tts_gui.py:145
+#: bookworm/text_to_speech/__init__.py:113
+#: bookworm/text_to_speech/__init__.py:124
+#: bookworm/text_to_speech/tts_gui.py:140
 msgid "Voice"
 msgstr "Voz"
 
-#: bookworm/text_to_speech/__init__.py:124
+#: bookworm/text_to_speech/__init__.py:121
 msgid "Back"
-msgstr ""
+msgstr "Atrás"
 
-#: bookworm/text_to_speech/__init__.py:125
+#: bookworm/text_to_speech/__init__.py:122
 msgid "Play"
 msgstr "Reproducir"
 
-#: bookworm/text_to_speech/__init__.py:126
+#: bookworm/text_to_speech/__init__.py:123
 msgid "Forward"
-msgstr ""
+msgstr "Adelante"
 
-#: bookworm/text_to_speech/__init__.py:217
+#: bookworm/text_to_speech/__init__.py:214
 msgid "End of document."
-msgstr ""
+msgstr "Fin del documento."
 
-#: bookworm/text_to_speech/__init__.py:237
+#: bookworm/text_to_speech/__init__.py:235
 msgid "End of section: {chapter}."
-msgstr "Fin de sección: {chapter}."
+msgstr "Fin de la sección: {chapter}."
 
 #. Translators: spoken message at the end of the document
-#: bookworm/text_to_speech/__init__.py:270
+#: bookworm/text_to_speech/__init__.py:268
 msgid "End of document"
-msgstr ""
+msgstr "Fin del documento"
 
 #. Translators: the title of a message telling the user that no TTS voice found
-#: bookworm/text_to_speech/__init__.py:421
+#: bookworm/text_to_speech/__init__.py:422
 msgid "No TTS Voices"
-msgstr "No hay voces TTS"
+msgstr "No hay Voces TTS"
 
 #. Translators: a message telling the user that no TTS voice found
-#: bookworm/text_to_speech/__init__.py:423
+#: bookworm/text_to_speech/__init__.py:424
 msgid ""
-"A valid Text-to-speech voice was not found for the current speech engine."
-"\n"
+"A valid Text-to-speech voice was not found for the current speech engine.\n"
 "Text-to-speech functionality will be disabled."
 msgstr ""
+"No se ha encontrado una voz de texto a voz válida para el motor de voz "
+"actual.\n"
+"La función de texto a voz se desactivará."
 
 #. Translators: a message telling the user that the TTS voice has been changed
-#: bookworm/text_to_speech/__init__.py:441
-#, fuzzy
+#: bookworm/text_to_speech/__init__.py:442
 msgid ""
 "Bookworm has noticed that the currently configured Text-to-speech voice "
-"speaks a language different from that of this book.\n"
+"speaks a language different from that of this document.\n"
 "Do you want to temporary switch to another voice that speaks a language "
-"similar to the language  of the currently opened document?"
+"similar to the language  of the currently opened document?\n"
+"\n"
+"Voice language: {voice_lang}\n"
+"Document language: {document_lang}"
 msgstr ""
-"Bookworm ha detectado que la voz actualmente configurada para el Texto a "
-"voz habla un idioma diferente al de este libro. Por lo tanto, Bookworm ha"
-" cambiado temporalmente a otra voz que habla un idioma similar al de este"
-" libro."
+"Bookworm se ha dado cuenta de que la voz de texto a voz actualmente "
+"configurada habla un idioma diferente al de este libro.\n"
+"¿Deseas cambiar temporalmente a otra voz que hable un idioma similar al del "
+"documento actualmente abierto?"
 
 #. Translators: the title of a message telling the user that the TTS voice has
 #. been changed
-#: bookworm/text_to_speech/__init__.py:448
+#: bookworm/text_to_speech/__init__.py:455
 msgid "Incompatible TTS Voice Detected"
-msgstr "Voz TTS incompatible"
-
-#: bookworm/text_to_speech/__init__.py:475
-#, fuzzy
-msgid "Search Result."
-msgstr "Resultados de la búsqueda"
-
-#: bookworm/text_to_speech/__init__.py:479
-#, fuzzy
-msgid "Bookmark."
-msgstr "Marcador"
-
-#: bookworm/text_to_speech/__init__.py:481
-#, fuzzy
-msgid "Bookmark: {bookmark_name}"
-msgstr "Marcadores | {book}"
+msgstr "Voz TTS incompatible detectada"
 
 #. Translators: the name of a built-in voice profile
-#: bookworm/text_to_speech/tts_config.py:124
+#: bookworm/text_to_speech/tts_config.py:125
 msgid "Human-like"
-msgstr "Como los humanos"
+msgstr "Parecido a un ser humano"
 
 #. Translators: the name of a built-in voice profile
-#: bookworm/text_to_speech/tts_config.py:135
+#: bookworm/text_to_speech/tts_config.py:136
 msgid "Deep Reading"
 msgstr "Lectura profunda"
 
 #. Translators: the name of a built-in voice profile
-#: bookworm/text_to_speech/tts_config.py:146
-#, fuzzy
+#: bookworm/text_to_speech/tts_config.py:147
 msgid "Express"
-msgstr "Expresivo"
+msgstr "Express"
 
 #. Translators: the label of a group of controls in the reading page
-#: bookworm/text_to_speech/tts_gui.py:49
+#: bookworm/text_to_speech/tts_gui.py:51
 msgid "Reading Options"
-msgstr "Opciones de lectura"
-
-#. Translators: the label of a checkbox to enable continuous reading
-#: bookworm/text_to_speech/tts_gui.py:54
-msgid "Use continuous reading mode"
-msgstr "Usar modo de lectura continua"
+msgstr "Opciones de Lectura"
 
 #. Translators: the title of a group of radio buttons in the reading page
 #. in the application settings related to how to read.
-#: bookworm/text_to_speech/tts_gui.py:62
+#: bookworm/text_to_speech/tts_gui.py:57
 msgid "When Pressing Play:"
-msgstr "Al reproducir:"
+msgstr "Al Pulsar Reproducir:"
 
 #. Translators: the label of a radio button
-#: bookworm/text_to_speech/tts_gui.py:67
+#: bookworm/text_to_speech/tts_gui.py:62
 msgid "Read the entire book"
 msgstr "Leer todo el libro"
 
 #. Translators: the label of a radio button
-#: bookworm/text_to_speech/tts_gui.py:69
+#: bookworm/text_to_speech/tts_gui.py:64
 msgid "Read the current section"
 msgstr "Leer la sección actual"
 
 #. Translators: the label of a radio button
-#: bookworm/text_to_speech/tts_gui.py:71
+#: bookworm/text_to_speech/tts_gui.py:66
 msgid "Read the current page"
 msgstr "Leer la página actual"
 
 #. Translators: the title of a group of radio buttons in the reading page
 #. in the application settings related to where to start reading from.
-#: bookworm/text_to_speech/tts_gui.py:79
+#: bookworm/text_to_speech/tts_gui.py:74
 msgid "Start reading from:"
-msgstr "Empezar a leer desde:"
+msgstr "Comenzar la Lectura desde:"
 
 #. Translators: the label of a radio button
-#: bookworm/text_to_speech/tts_gui.py:83
+#: bookworm/text_to_speech/tts_gui.py:78
 msgid "Cursor position"
-msgstr "Posición del cursor"
+msgstr "Posición del Cursor"
 
-#: bookworm/text_to_speech/tts_gui.py:83
+#: bookworm/text_to_speech/tts_gui.py:78
 msgid "Beginning of page"
-msgstr "Inicio de la página"
+msgstr "Comienzo de la página"
 
 #. Translators: the label of a group of controls in the reading page
 #. of the settings related to behavior during reading  aloud
-#: bookworm/text_to_speech/tts_gui.py:87
+#: bookworm/text_to_speech/tts_gui.py:82
 msgid "During Reading Aloud"
-msgstr "Durante la lectura"
+msgstr "Durante la lectura en voz alta"
+
+#: bookworm/text_to_speech/tts_gui.py:87
+msgid "Speak page number"
+msgstr "Verbalizar los números de página"
 
 #. Translators: the label of a checkbox
-#: bookworm/text_to_speech/tts_gui.py:99
-#, fuzzy
+#: bookworm/text_to_speech/tts_gui.py:94
 msgid "Announce the end of sections"
-msgstr "Reproducir sonido para fin de sección"
+msgstr "Anunciar el fin de las secciones"
 
 #. Translators: the label of a checkbox
-#: bookworm/text_to_speech/tts_gui.py:106
+#: bookworm/text_to_speech/tts_gui.py:101
 msgid "Ask to switch to a voice that speaks the language of the current book"
-msgstr ""
+msgstr "Pedir que se cambie a una voz que hable el idioma del libro actual"
 
 #. Translators: the label of a checkbox
-#: bookworm/text_to_speech/tts_gui.py:113
+#: bookworm/text_to_speech/tts_gui.py:108
 msgid "Highlight spoken text"
-msgstr "Resaltar texto leído"
+msgstr "Resaltar el texto hablado"
 
 #. Translators: the label of a checkbox
-#: bookworm/text_to_speech/tts_gui.py:120
+#: bookworm/text_to_speech/tts_gui.py:115
 msgid "Select spoken text"
-msgstr "Seleccionar texto leído"
+msgstr "Seleccionar el texto hablado"
 
 #. Translators: the label of a combobox containing a list of tts engines
-#: bookworm/text_to_speech/tts_gui.py:148
+#: bookworm/text_to_speech/tts_gui.py:143
 msgid "Speech Engine:"
-msgstr "Motor de Voz"
+msgstr "Motor de Voz:"
 
 #. Translators: the label of a button that opens a dialog to change the speech
 #. engine
-#: bookworm/text_to_speech/tts_gui.py:153
+#: bookworm/text_to_speech/tts_gui.py:148
 msgid "Change..."
 msgstr "Cambiar..."
 
 #. Translators: the label of a combobox containing a list of tts voices
-#: bookworm/text_to_speech/tts_gui.py:156
+#: bookworm/text_to_speech/tts_gui.py:151
 msgid "Select Voice:"
-msgstr "Seleccionar una voz"
+msgstr "Seleccionar Voz:"
 
 #. Translators: the label of the speech rate slider
-#: bookworm/text_to_speech/tts_gui.py:159
+#: bookworm/text_to_speech/tts_gui.py:154
 msgid "Speech Rate:"
-msgstr "Velocidad de voz"
+msgstr "Velocidad de la Voz:"
+
+#. Translators: the label of the voice pitch slider
+#: bookworm/text_to_speech/tts_gui.py:160
+msgid "Voice Pitch:"
+msgstr "Tono de Voz:"
 
 #. Translators: the label of the speech volume slider
-#: bookworm/text_to_speech/tts_gui.py:165
+#: bookworm/text_to_speech/tts_gui.py:166
 msgid "Speech Volume:"
-msgstr "Volumen de voz"
+msgstr "Volumen de la Voz:"
 
 #. Translators: the label of a group of controls in the speech
 #. settings page related to speech pauses
-#: bookworm/text_to_speech/tts_gui.py:172
+#: bookworm/text_to_speech/tts_gui.py:173
 msgid "Pauses"
 msgstr "Pausas"
 
 #. Translators: the label of an edit field
-#: bookworm/text_to_speech/tts_gui.py:175
+#: bookworm/text_to_speech/tts_gui.py:176
 msgid "Additional Pause At Sentence End (Ms)"
-msgstr "Pausa adicional al final de frase (Ms)"
+msgstr "Pausa adicional en el Final de la Frase (Ms)"
 
 #. Translators: the label of an edit field
-#: bookworm/text_to_speech/tts_gui.py:180
+#: bookworm/text_to_speech/tts_gui.py:181
 msgid "Additional Pause At Paragraph End (Ms)"
-msgstr "Pausa adicional al final del párrafo (Ms)"
+msgstr "Pausa Adicional en el Final del Párrafo (Ms)"
 
 #. Translators: the label of an edit field
-#: bookworm/text_to_speech/tts_gui.py:185
+#: bookworm/text_to_speech/tts_gui.py:186
 msgid "End of Page Pause (ms)"
-msgstr "Pausa al final de página (ms)"
+msgstr "Pausa al Final de la Página (ms)"
 
 #. Translators: the label of an edit field
-#: bookworm/text_to_speech/tts_gui.py:194
+#: bookworm/text_to_speech/tts_gui.py:195
 msgid "End of Section Pause (ms)"
-msgstr "Pausa al final de sección (ms)"
+msgstr "Pausa al Final de la Sección (ms)"
 
-#: bookworm/text_to_speech/tts_gui.py:238
+#: bookworm/text_to_speech/tts_gui.py:239
 msgid "Speech Engine"
-msgstr "Motor de voz"
+msgstr "Motor de Voz"
 
 #. Translators: the title of a dialog to edit a voice profile
-#: bookworm/text_to_speech/tts_gui.py:285
+#: bookworm/text_to_speech/tts_gui.py:288
 msgid "Voice Profile: {profile}"
-msgstr "Perfil de voz: {profile}"
+msgstr "Perfil de Voz: {profile}"
 
 #. Translators: the label of a combobox to select a voice profile
-#: bookworm/text_to_speech/tts_gui.py:312
+#: bookworm/text_to_speech/tts_gui.py:315
 msgid "Select Voice Profile:"
-msgstr "Seleccionar perfil de voz:"
+msgstr "Seleccionar Perfil de Voz:"
 
 #. Translators: the label of a button to activate a voice profile
-#: bookworm/text_to_speech/tts_gui.py:318
+#: bookworm/text_to_speech/tts_gui.py:321
 msgid "&Activate"
 msgstr "&Activar"
 
 #. Translators: the label of a button to create a new voice profile
-#: bookworm/text_to_speech/tts_gui.py:324
+#: bookworm/text_to_speech/tts_gui.py:327
 msgid "&New Profile..."
-msgstr "&Nuevo perfil..."
+msgstr "Perfil &Nuevo..."
 
 #. Translators: the entry of the active voice profile in the voice profiles
 #. list
-#: bookworm/text_to_speech/tts_gui.py:358
+#: bookworm/text_to_speech/tts_gui.py:361
 msgid "{profile} (active)"
 msgstr "{profile} (activo)"
 
 #. Translators: the label of an edit field to enter the voice profile name
-#: bookworm/text_to_speech/tts_gui.py:408
+#: bookworm/text_to_speech/tts_gui.py:411
 msgid "Profile Name:"
-msgstr "Nombre del perfil:"
+msgstr "Nombre de Perfil:"
 
 #. Translators: the title of a dialog to enter the name of a new voice profile
-#: bookworm/text_to_speech/tts_gui.py:410
+#: bookworm/text_to_speech/tts_gui.py:413
 msgid "New Voice Profile"
-msgstr "Nuevo perfil de voz"
+msgstr "Nuevo Perfil de Voz"
 
 #. Translators: the content of a message notifying the user
 #. user of the existence of a voice profile with the same name
-#: bookworm/text_to_speech/tts_gui.py:422
+#: bookworm/text_to_speech/tts_gui.py:425
 msgid ""
 "A voice profile with the same name already exists. Please select another "
 "name."
 msgstr ""
-"Ya existe un perfil de voz con el mismo nombre. Por favor, seleccione uno"
-" distinto."
+"Ya existe un perfil de voz con el mismo nombre. Por favor, selecciona otro "
+"nombre."
 
 #. Translators: the content of a message telling the user that the voice
 #. profile he is removing is the active one
-#: bookworm/text_to_speech/tts_gui.py:448
+#: bookworm/text_to_speech/tts_gui.py:451
 msgid ""
 "Voice profile {profile} is the active profile.\n"
 "Please deactivate it first by clicking 'Deactivate Active Voice Profile` "
 "menu item from the speech menu."
 msgstr ""
-"El perfil de voz  {profile} se encuentra activo.\n"
-"Por favor, desactívelo primero haciendo clic en \"Desactivar perfil de "
-"voz en ejecución\" desde el menú voz."
+"El perfil de Voz {profile} es el perfil activo.\n"
+"Por favor desactívalo primero haciendo clic en el elemento de menú "
+"'Desactivar Perfil de Voz Activo` desde el menú Voz."
 
 #. Translators: the title of a message telling the user that
 #. it is not possible to remove this voice profile
-#: bookworm/text_to_speech/tts_gui.py:455
+#: bookworm/text_to_speech/tts_gui.py:458
 msgid "Cannot Remove Profile"
-msgstr "No se puede eliminar el perfil"
+msgstr "No se puede Eliminar el Perfil"
 
 #. Translators: the title of a message to confirm the removal of the voice
 #. profile
-#: bookworm/text_to_speech/tts_gui.py:461
+#: bookworm/text_to_speech/tts_gui.py:464
 msgid ""
 "Are you sure you want to remove voice profile {profile}?\n"
 "This cannot be undone."
 msgstr ""
-"¿Seguro de que desea eliminar el perfil de voz  {profile}?\n"
-"Esta acción no puede deshacerse."
+"¿Estás seguro de que quieres eliminar el perfil de voz {profile}?\n"
+"Esto no se puede deshacer."
 
 #. Translators: the title of a message to confirm the removal of a voice
 #. profile
-#: bookworm/text_to_speech/tts_gui.py:466
+#: bookworm/text_to_speech/tts_gui.py:469
 msgid "Remove Voice Profile?"
-msgstr "¿Eliminar perfil de voz?"
+msgstr "¿Eliminar Perfil de Voz?"
 
 #. Translators: the label of a combobox
-#: bookworm/text_to_speech/tts_gui.py:489
+#: bookworm/text_to_speech/tts_gui.py:492
 msgid "Select Speech Engine:"
-msgstr "Seleccionar motor de voz:"
+msgstr "Seleccionar Motor de Voz:"
 
 #. Translators: the label of an item in the application menubar
-#: bookworm/text_to_speech/tts_gui.py:518
+#: bookworm/text_to_speech/tts_gui.py:521
 msgid "&Play\tF5"
 msgstr "&Reproducir\tF5"
 
 #. Translators: the help text of an item in the application menubar
-#: bookworm/text_to_speech/tts_gui.py:520
+#: bookworm/text_to_speech/tts_gui.py:523
 msgid "Start reading aloud"
-msgstr "Empieza a leer en voz alta"
+msgstr "Comenzar a leer en voz alta"
 
 #. Translators: the label of an item in the application menubar
-#: bookworm/text_to_speech/tts_gui.py:525
+#: bookworm/text_to_speech/tts_gui.py:528
 msgid "Pa&use/Resume\tF6"
-msgstr "Pa&usa/Reanudar\tF6"
+msgstr "&Pausar/Reanudar\tF6"
 
 #. Translators: the help text of an item in the application menubar
-#: bookworm/text_to_speech/tts_gui.py:527
+#: bookworm/text_to_speech/tts_gui.py:530
 msgid "Pause/Resume reading aloud"
 msgstr "Pausa o reanuda la lectura en voz alta"
 
 #. Translators: the label of an item in the application menubar
-#: bookworm/text_to_speech/tts_gui.py:532
+#: bookworm/text_to_speech/tts_gui.py:535
 msgid "&Stop\tF7"
 msgstr "&Detener\tF7"
 
 #. Translators: the help text of an item in the application menubar
-#: bookworm/text_to_speech/tts_gui.py:534
+#: bookworm/text_to_speech/tts_gui.py:537
 msgid "Stop reading aloud"
 msgstr "Detiene la lectura en voz alta"
 
 #. Translators: the label of an item in the application menubar
-#: bookworm/text_to_speech/tts_gui.py:539
+#: bookworm/text_to_speech/tts_gui.py:542
 msgid "&Rewind\tAlt-LeftArrow"
-msgstr "&Rebobinar\tAlt-¡+Izquierda"
+msgstr "Re&bobinado\tAlt-VlechaIzquierda"
 
 #. Translators: the help text of an item in the application menubar
-#: bookworm/text_to_speech/tts_gui.py:541
+#: bookworm/text_to_speech/tts_gui.py:544
 msgid "Skip to previous paragraph"
-msgstr "Saltar al párrafo anterior"
+msgstr "Salta al párrafo anterior"
 
 #. Translators: the label of an item in the application menubar
-#: bookworm/text_to_speech/tts_gui.py:546
+#: bookworm/text_to_speech/tts_gui.py:549
 msgid "&Fast Forward\tAlt-RightArrow"
-msgstr "&Avance rápido\tAlt+Derecha"
+msgstr "&Avance rápido\tAlt-FlechaDerecha"
 
 #. Translators: the help text of an item in the application menubar
-#: bookworm/text_to_speech/tts_gui.py:548
+#: bookworm/text_to_speech/tts_gui.py:551
 msgid "Skip to next paragraph"
-msgstr "Saltar al párrafo siguiente"
+msgstr "Salta al párrafo siguiente"
 
 #. Translators: the label of an item in the application menubar
-#: bookworm/text_to_speech/tts_gui.py:553
+#: bookworm/text_to_speech/tts_gui.py:556
 msgid "&Voice Profiles\tCtrl-Shift-V"
-msgstr "&Perfiles de voz\tCtrl-Shift-V"
+msgstr "Perfiles de &Voz\tCtrl-Shift-V"
 
 #. Translators: the help text of an item in the application menubar
-#: bookworm/text_to_speech/tts_gui.py:555
+#: bookworm/text_to_speech/tts_gui.py:558
 msgid "Manage voice profiles."
-msgstr "Gestiona los perfiles de voz."
+msgstr "Administrar Perfiles de Voz."
 
 #. Translators: the label of an item in the application menubar
-#: bookworm/text_to_speech/tts_gui.py:560
+#: bookworm/text_to_speech/tts_gui.py:563
 msgid "&Deactivate Active Voice Profile"
-msgstr "&Desactivar perfil de voz en ejecución"
+msgstr "&Desactivar Perfil de Voz Activo"
 
 #. Translators: the help text of an item in the application menubar
-#: bookworm/text_to_speech/tts_gui.py:562
+#: bookworm/text_to_speech/tts_gui.py:565
 msgid "Deactivate the active voice profile."
-msgstr "Desactiva el perfil de voz en ejecución actual"
-
-#. Translators: the label of an item in the application menubar
-#: bookworm/text_to_speech/tts_gui.py:567
-msgid "S&peech"
-msgstr ""
+msgstr "Desactiva el perfil de voz activo."
 
 #. Translators: a message that is announced when the speech is paused
 #: bookworm/text_to_speech/tts_gui.py:627
 msgid "Paused"
-msgstr "En pausa"
+msgstr "Pausado"
 
 #. Translators: a message that is announced when the speech is resumed
 #: bookworm/text_to_speech/tts_gui.py:631
@@ -2494,96 +3946,155 @@ msgstr "Detenido"
 #. Translators: the title of the voice profiles dialog
 #: bookworm/text_to_speech/tts_gui.py:646
 msgid "Voice Profiles"
-msgstr "Perfiles de voz"
+msgstr "Perfiles de Voz"
 
-#: bookworm/webservices/__init__.py:21
+#. Translators: the label of an item in the application menubar
+#: bookworm/webservices/__init__.py:23
 msgid "&Web Services"
-msgstr ""
+msgstr "Servicios &Web"
 
-#: bookworm/webservices/url_open.py:33
+#: bookworm/webservices/url_open.py:34
 msgid "&Open URL\tCtrl+U"
-msgstr ""
+msgstr "&Abrir URL\tCtrl+U"
 
-#: bookworm/webservices/url_open.py:35
+#: bookworm/webservices/url_open.py:36
 msgid "&Open URL From Clipboard\tCtrl+Shift+U"
-msgstr ""
+msgstr "Abrir URL desde el &Portapapeles\tCtrl+Shift+U"
 
 #. Translators: title of a dialog for entering a URL
-#: bookworm/webservices/url_open.py:48
-#, fuzzy
+#: bookworm/webservices/url_open.py:49
 msgid "Enter URL"
-msgstr "General"
+msgstr "Introducir URL"
 
 #. Translators: label of a textbox in a dialog for entering a URL
-#: bookworm/webservices/url_open.py:50
+#: bookworm/webservices/url_open.py:51
 msgid "URL"
-msgstr ""
+msgstr "URL"
 
-#: bookworm/webservices/wikiworm.py:34
+#: bookworm/webservices/wikiworm.py:57
 msgid "&Wikipedia quick search"
-msgstr ""
+msgstr "Búsqueda rápida en &Wikipedia"
 
-#: bookworm/webservices/wikiworm.py:35
+#: bookworm/webservices/wikiworm.py:58
 msgid "Get a quick definition from Wikipedia"
-msgstr ""
+msgstr "Obtiene una definición rápida de Wikipedia"
 
-#: bookworm/webservices/wikiworm.py:47
+#: bookworm/webservices/wikiworm.py:70
 msgid "Define using Wikipedia"
-msgstr ""
+msgstr "Definir utilizando Wikipedia"
 
-#: bookworm/webservices/wikiworm.py:48
+#: bookworm/webservices/wikiworm.py:71
 msgid "Define the selected text using Wikipedia"
-msgstr ""
+msgstr "Definir el texto seleccionado utilizando Wikipedia"
 
-#: bookworm/webservices/wikiworm.py:62
-msgid "Wikipedia Quick Search"
-msgstr ""
-
-#: bookworm/webservices/wikiworm.py:63
-#, fuzzy
-msgid "Enter term"
-msgstr "Término de búsqueda:"
-
-#: bookworm/webservices/wikiworm.py:75
+#: bookworm/webservices/wikiworm.py:105
 msgid "Retrieving information, please wait..."
-msgstr ""
+msgstr "Recuperando información, por favor espera..."
 
-#: bookworm/webservices/wikiworm.py:108
-#, fuzzy
+#: bookworm/webservices/wikiworm.py:136
 msgid ""
-"Could not connect to Wikipedia at the moment.\\Please make sure that "
-"you're connected to the internet or try again later."
+"Could not connect to Wikipedia at the moment.\\Please make sure that you're "
+"connected to the internet or try again later."
 msgstr ""
-"Ocurrió un error de red al descargar la actualización.\n"
-"Asegúrese de estar conectado a Internet o inténtelo de nuevo más tarde."
+"No se pudo conectar con Wikipedia en este momento.\\Por favor asegúrate de "
+"que estás conectado a internet o inténtalo de nuevo más tarde."
 
-#: bookworm/webservices/wikiworm.py:118
-msgid "Could not get the definition from Wikipedia."
-msgstr ""
+#. Translators: title of a message box
+#: bookworm/webservices/wikiworm.py:147
+msgid "Page not found"
+msgstr "Página no encontrada"
 
-#: bookworm/webservices/wikiworm.py:125
-msgid "Matches"
-msgstr ""
-
-#: bookworm/webservices/wikiworm.py:126
-msgid "Multiple Matches Found"
-msgstr ""
-
+#. Translators: content of a message box
 #: bookworm/webservices/wikiworm.py:149
-msgid "{term} — Wikipedia"
-msgstr ""
+msgid "Could not find a Wikipedia page for the given term.."
+msgstr "No se pudo encontrar una página de Wikipedia para el término dado.."
 
-#. Translators: label of an edit control in the dialog
-#. of viewing or editing a comment/highlight
+#: bookworm/webservices/wikiworm.py:155
+msgid "Matches"
+msgstr "Coincidencias"
+
 #: bookworm/webservices/wikiworm.py:156
+msgid "Multiple Matches Found"
+msgstr "Encontradas múltiples coincidencias"
+
+#: bookworm/webservices/wikiworm.py:171
+msgid "Failed to get term definition from Wikipedia."
+msgstr "Error obteniendo la definición del término en Wikipedia."
+
+#: bookworm/webservices/wikiworm.py:188
+msgid "{term} — Wikipedia"
+msgstr "{term} — Wikipedia"
+
+#. Translators: label of a read only edit control showing Wikipedia article
+#. summary
+#: bookworm/webservices/wikiworm.py:194
 msgid "Summary"
-msgstr ""
+msgstr "Resumen"
 
-#: bookworm/webservices/wikiworm.py:167
+#: bookworm/webservices/wikiworm.py:205
 msgid "Open in &Bookworm"
-msgstr ""
+msgstr "Abrir en &Bookworm"
 
-#: bookworm/webservices/wikiworm.py:168
+#: bookworm/webservices/wikiworm.py:206
 msgid "&Open in Browser"
-msgstr ""
+msgstr "&Abrir en Navegador"
 
+#. Translators: the title of a dialog to search for a term in Wikipedia
+#: bookworm/webservices/wikiworm.py:238
+msgid "Wikipedia Quick Search"
+msgstr "Búsqueda Rápida en Wikipedia"
+
+#. Translators: label of an edit control in the search Wikipedia dialog
+#: bookworm/webservices/wikiworm.py:244
+msgid "Enter term"
+msgstr "Introducir término"
+
+#. Translators: label of a combobox  that shows a list of languages to search
+#. in Wikipedia
+#: bookworm/webservices/wikiworm.py:250
+msgid "Choose Wikipedia language"
+msgstr "Elegir Idioma de Wikipedia"
+
+#~ msgid "Exclude named bookmarks when jumping between bookmarks"
+#~ msgstr "Excluir marcas con nombre al saltar entre marcas"
+
+#~ msgid "Use sounds to indicate the presence of comments"
+#~ msgstr "Utilizar sonidos para indicar la presencia de comentarios"
+
+#~ msgid ""
+#~ "Failed to retrieve document information.\n"
+#~ "Please try again."
+#~ msgstr ""
+#~ "Error al recolectar la información del documento.\n"
+#~ "Por favor inténtalo de nuevo."
+
+#~ msgid "Book contents"
+#~ msgstr "Contenidos de libro"
+
+#~ msgid "Speak section title"
+#~ msgstr "Verbalizar títulos de sección"
+
+#~ msgid "&Find &Next\tF3"
+#~ msgstr "Buscar &Siguiente\tF3"
+
+#~ msgid "&Find &Previous\tShift-F3"
+#~ msgstr "Encontrar &Anterior\tShift-F3"
+
+#~ msgid "Recognition Language:"
+#~ msgstr "Idioma de Reconocimiento:"
+
+#~ msgid ""
+#~ "A version of the selected language model already exists.\n"
+#~ "Are you sure you want to replace it."
+#~ msgstr ""
+#~ "Ya existe una versión del modelo lingüístico seleccionado.\n"
+#~ "¿Estás seguro de que deseas sustituirla."
+
+#~ msgid "OCR Results"
+#~ msgstr "Resultados del OCR"
+
+#~ msgid "Use continuous reading mode"
+#~ msgstr "Utilizar el modo de lectura continua"
+
+#~ msgid "Could not get the definition from Wikipedia."
+#~ msgstr "No se ha podido obtener la definición en Wikipedia."

--- a/bookworm/resources/userguide/es/bookworm.md
+++ b/bookworm/resources/userguide/es/bookworm.md
@@ -1,194 +1,227 @@
-# Manual de Usuario de Bookworm
+# Guía de usuario de Bookworm
 
 ## Introducción
 
-**Bookworm** es un lector de Ebooks accesible que le permite a las personas ciegas y de baja visión leer libros electrónicos de manera fácil y sin complicaciones. Entre lo destacable de Bookworm se encuentra:
+Bookworm es un lector de documentos que le permite leer PDF, EPUB, MOBI y muchos otros formatos de documentos utilizando una interfaz versátil, pero sencilla y muy accesible.
 
-* Soporte para los formatos de E-book más populares, incluyendo EPUB y PDF
-* Usted puede agregar marcadores con nombre indicando posiciones de interés en el texto para una referencia posterior
-* Usted puede añadir notas para capturar opiniones de interés o crear un resumen del contenido en una posición específica del texto. Bookworm le permite desplazarse a una nota que desee para su revisión. Después, podrá exportar dichas notas a un archivo de texto o a un documento HTML para una referencia posterior.
-* Hay dos estilos diferentes para visualizar las páginas: texto plano e imágenes completamente renderizadas y acercables.
-* Búsqueda completa de texto con opciones de búsqueda personalizables
-* Se soporta ampliamente la navegación del libro por tabla de contenidos para todos los formatos
-* Soporte para la lectura de libros en voz alta usando Texto a Voz, con parámetros de voz configurables.
-* Es posible personalizar el texto a voz mediante perfiles. ¡Cada perfil de voz configura el estilo de la voz y usted puede activar/desactivar cada perfil, incluso mientras se lee en voz alta!
-* Soporta comandos estándar para acercar/alejar/restablecer zoom, Ctrl + =, Ctrl + - y Ctrl + 0 respectivamente. Esta funcionalidad está disponible tanto en la vista de texto plano como en la página renderizada.
-* Se soporta la exportación de cualquier E-book a un archivo de texto plano.
+Bookworm te proporciona un rico conjunto de herramientas para leer tus documentos. Puede buscar en sus documentos, marcar y resaltar contenidos de interés, utilizar la conversión de texto a voz y convertir documentos escaneados a texto sin formato mediante el reconocimiento óptico de caracteres (OCR).
+
+Bookworm funciona con el sistema operativo Microsoft Windows. Funciona bien con tus lectores de pantalla favoritos, como NVDA y JAWS. Incluso cuando un lector de pantalla no está activo, Bookworm puede actuar como una aplicación de voz utilizando las funciones incorporadas de texto a voz.
+
+
+## Características
+
+* Admite más de 15 formatos de documento, incluidos EPUB, PDF, MOBI y documentos de Microsoft Word.
+* Admite navegación estructurada mediante comandos de navegación de una sola letra para saltar entre títulos, listas, tablas y citas
+* Búsqueda de texto completo con opciones de búsqueda personalizables
+* Herramientas de anotación avanzadas y fáciles de usar. Puede añadir marcadores con nombre para marcar lugares de interés en el texto para su posterior consulta, y puede añadir comentarios para capturar un pensamiento interesante o crear un resumen del contenido en una posición concreta del texto. Bookworm te permite saltar rápidamente a un comentario concreto y visualizarlo. Más tarde, puede exportar estos comentarios a un archivo de texto o documento HTML para su uso posterior.
+* Para los documentos PDF, Bookworm admite dos estilos diferentes de visualización de las páginas: texto sin formato e imágenes con zoom.
+* Soporta el uso de OCR para extraer texto de documentos e imágenes escaneados utilizando el motor OCR integrado de Windows10. También tiene la opción de descargar y utilizar el motor de OCR Tesseract disponible gratuitamente dentro de Bookworm.
+* Busque la definición de un término en Wikipedia y lea artículos de Wikipedia desde Bookworm.
+* Un extractor de artículos web incorporado que le permite abrir URLs y extraer automáticamente el artículo principal de la página.
+* La navegación de documentos a través de la tabla de contenido está ampliamente soportada para todos los formatos de documento.
+* Soporte para lectura de libros en voz alta usando Texto-a-voz, con opciones de voz personalizables usando perfiles de voz.
+* Soporte para zoom de texto usando los comandos estándar de zoom-in/zoom-out/reset.
+* Soporte para exportar cualquier formato de documento a un archivo de texto plano.
 
 
 ## Instalación
 
-Para hacer que Bookworm funcione en su equipo, siga estos pasos:
+Para instalar y ejecutar Bookworm en su ordenador, visite primero el [sitio web oficial de Bookworm](https://github.com/blindpandas/bookworm)
 
-1. Lleve su navegador al  [sitio oficial de Bookworm](https://mush42.github.io/bookworm/) y descargue el instalador que corresponda a su sistema operativo. Bookworm se distribuye de dos formas: 
+Bookworm está disponible en tres versiones:
 
-* Un instalador para ejecutarse en la variante 32 bits de Windows
-* Un instalador para equipos con una variante 64 bits de Windows 
+* Instalador de 32 bits para ordenadores con Windows de 32 o 64 bits.
+* Instalador de 64 bits para ordenadores con Windows de 64 bits.
+* Versión portable para ejecutar desde una unidad flash
 
-2. Abra el instalador y siga las instrucciones
-3. Después de que la instalación se haya completado con éxito, puede iniciar Bookworm desde el escritorio o desde la lista de programas ubicada en el menú inicio
+Si tiene voces SAPI5 heredadas instaladas en su sistema y desea utilizarlas con Bookworm, le recomendamos que instale la versión de 32 bits de Bookworm o que utilice la versión portable de 32 bits.
+
+Tras seleccionar la versión que más te convenga, descárgala. Si has descargado la versión instalable de Bookworm, ejecuta el archivo .exe y sigue las instrucciones que aparecen en pantalla, o si has optado por utilizar una copia portable de Bookworm, descomprime el contenido del archivo donde quieras y ejecuta el ejecutable de Bookworm para iniciar la copia portable.
 
 
 ## Uso
 
-### Abriendo un libro
 
-puede abrir un libro seleccionando la opción  "Abrir..." desde el menú archivo. Como alternativa, puede usar el atajo de teclado Ctrl+O. De cualquier forma, se mostrará un conocido diálogo para abrir archivos. Navegue hasta el ebook y seleccione abrir para que se cargue.
+### Abrir un documento
+
+Puede abrir un documento seleccionando la opción «Abrir...» del menú «Archivo». También puede utilizar el atajo de teclado Ctrl+O. En cualquiera de los dos casos, aparecerá el conocido cuadro de diálogo «Abrir archivo». Busque su documento y haga clic en Abrir para cargarlo.
+
 
 ### La ventana del lector
 
-La ventana principal de Bookworm se compone de dos partes:
+La ventana principal de Bookworm consta de las dos partes siguientes:
 
-1. La "Tabla de contenido": Aquí aparecerán los capítulos del libro. Esto le permite explorar la estructura del contenido. Use las teclas de navegación para navegar por los capítulos y presione enter para desplazarse al que desee.
-2. El área textual visible: Esta parte contiene el texto de la página actual. En esta sección puede usar los comandos regulares de lectura para navegar por el texto. Además, dispone de los siguientes comandos de teclado para navegar por el libro::
+1. La «Tabla de contenidos»: Esta parte muestra los capítulos del documento. Le permite explorar la estructura del contenido. Utilice las teclas de navegación para navegar por los capítulos, y pulse intro para navegar a un capítulo específico.
 
-* Enter: se desplaza a la siguiente página en la sección actual
-* Retroceso: se desplaza a la página anterior en la sección actual
-* Si el cursor está en la primera línea, presionando la flecha arriba dos veces seguidas le llevará a la página anterior.
-* Si el cursor está en la última línea, presionando la flecha abajo dos veces seguidas le llevará a la página siguiente.
-* Alt + Inicio: se desplaza a la primera página de la sección actual
-* Alt + Fin: se desplaza a la última página de la sección actual
-* Alt + Avance de página: se desplaza a la sección siguiente
-* Alt + Retroceso de página: se desplaza a la sección anterior
+2. El área «Vista textual»: Esta parte contiene el texto de la página actual. En esta parte puede utilizar sus comandos de lectura habituales para navegar por el texto. Además, puede utilizar los siguientes atajos de teclado para navegar por el documento:
+
+* Intro: pasar a la página siguiente de la sección actual.
+* Retroceso: navegar a la página anterior de la sección actual.
+* Mientras el cursor está en la primera línea, pulsando dos veces seguidas la flecha hacia arriba se pasa a la página anterior.
+* Mientras el cursor está en la última línea, pulsando dos veces seguidas la flecha hacia abajo se pasa a la página siguiente.
+* Alt + Inicio: navegar a la primera página de la sección actual.
+* Alt + Fin: navegar a la última página de la sección actual.
+* Alt + página abajo: navegar a la sección siguiente.
+* Alt + página arriba: navegar a la sección anterior;
+* F2: ir al siguiente marcador;
+* Mayús + F2: ir al marcador anterior;
+* F8: ir al comentario siguiente;
+* Mayús + F8: ir al comentario anterior;
+* F9: ir al siguiente resaltado
+* Shift + F9: ir al resaltado anterior;
+* ctrl + enter: abrir cualquier enlace interno o externo si el documento lo contiene. Los enlaces internos son enlaces creados por el índice del documento en algunos formatos, los enlaces externos son enlaces normales abiertos por el navegador. Dependiendo del tipo de enlace, si el enlace es interno, es decir, el enlace a la tabla de contenidos, al pulsar el atajo de teclado anterior se moverá el foco a la tabla de contenidos deseada, y si el enlace es externo, se abrirá en el navegador predeterminado del sistema.
 
 
-### Marcadores y notas
+### Marcadores y comentarios
 
-Bookworm le permite  hacer anotaciones en el libro actualmente abierto. Puede agregar un marcador para recordar una posición específica en el libro y, más tarde, saltar rápidamente hacia ella. También puede tomar una nota para capturar una idea o resumir su contenido.
+Bookworm le permite hacer anotaciones en un documento abierto. Puede añadir un marcador para recordar una ubicación específica en un documento y saltar rápidamente a ella. Además, puede añadir un comentario para capturar una idea o resumir el contenido.
 
-#### Agregar marcadores
 
-Durante la lectura, puede presionar Ctrl + B (o seleccionar el elemento "Agregar marcador" desde el menú "Anotaciones") para añadir un marcador. Éste se añadirá en la posición actual del cursor. Se le pedirá que proporcione un título para el marcador. Escriba el título que desee y haga clic en el botón Aceptar. Se añadirá un marcador en la posición correspondiente y la línea actual se verá resaltada.
+#### Añadir marcadores
 
-#### Visualizando marcadores
+Mientras lees un documento, puedes pulsar Ctrl + B (o seleccionar la opción de menú Añadir marcador) en el menú Anotaciones para añadir un marcador. El marcador se añadirá en la posición actual del cursor. Alternativamente, puede añadir un marcador con nombre pulsando ctrl+mayús+b, se abrirá una ventana que le pedirá el nombre del marcador o, alternativamente, seleccione Añadir marcador con nombre en el menú Anotaciones.
 
-Presione Ctrl + Shift + B o seleccione la opción "Ver marcadores" del menú "Anotaciones". Se mostrará un diálogo con los marcadores agregados. Haciendo clic en cualquier elemento de la lista de marcadores le llevará a la posición de dicho marcador.
 
-Adicionalmente, puede presionar F2 para editar el título del marcador en cuestión, o puede hacer clic en el botón "eliminar", o presionar la tecla "Suprimir"  del teclado para eliminar el marcador seleccionado.
+#### Visualización de marcadores
 
-#### Tomar notas
+Vaya al menú Anotaciones y seleccione la opción «Ver marcadores». Aparecerá un cuadro de diálogo con los marcadores añadidos. Al hacer clic en cualquier elemento de la lista de marcadores, accederá inmediatamente a la posición de ese marcador. Alternativamente, para saltar rápidamente a través de los marcadores añadidos, puedes utilizar las teclas f2 y shift+f2, que irán directamente a la posición del cursor del marcador.
 
-Durante la lectura de un libro, puede presionar Ctrl + N o elegir  la opción "tomar nota" del menú "anotaciones" para proceder. Se agregará una nota en la posición actual del cursor. Se le pedirá que especifique un título y el contenido para la nota. Escriba el título deseado y el contenido y haga clic en el botón Aceptar. Se creará una nota en la ubicación actual.
 
-Cuando navegue a una página que contenga al menos una nota, se oirá un sonido indicando que existe una nota en esa página.
+#### Añadir comentarios
 
-#### Gestionando las notas
+Mientras lees un documento, puedes pulsar Ctrl+m (o seleccionar la opción de menú Añadir comentario) en el menú Anotaciones para añadir un comentario. Se te pedirá el contenido del comentario. Introduzca el contenido y haga clic en «Aceptar». El comentario se añadirá en la ubicación actual.
 
-Presione Ctrl + Shift + N o seleccione el elemento "Gestionar notas" del menú "Anotaciones". Se mostrará un diálogo con las notas agregadas. Haciendo clic en la lista de notas lo llevará inmediatamente a la posición de la nota. Eligiendo el botón "Ver" se abrirá un diálogo mostrando el título y el contenido de la nota seleccionada.
+Cuando vaya a una página que contenga al menos un comentario, oirá un pequeño sonido que le indicará que hay un comentario en la página actual.
 
-También puede hacer clic en el botón "Editar" para editar el título y el contenido de la nota, presionar F2 para cambiar el título de la nota en cuestión, o puede hacer clic en el botón "Eliminar", o presionar suprimir en el teclado.
 
-#### Exportando las notas
+#### Gestión de comentarios
 
-Bookworm le permite exportar sus notas a un archivo de texto plano o a un documento HTML, el cual podrá abrir en su explorador web. Bookworm también le permite opcionalmente exportar sus notas a markdown, que es un formato de texto base estructurado popular entre usuarios informáticos expertos.
+Seleccione la opción «Comentarios guardados» del menú «Anotaciones». Aparecerá un cuadro de diálogo con los comentarios añadidos. Si hace clic en cualquier elemento de la lista de comentarios, saltará inmediatamente a la posición de ese comentario. Al hacer clic en el botón «Ver» se abrirá un cuadro de diálogo que mostrará la etiqueta y el contenido del comentario seleccionado.
 
-Para exportar las notas, siga estos pasos:
+También puede hacer clic en el botón «Editar» para cambiar la etiqueta y el contenido del comentario seleccionado, pulsar F2 para editar la etiqueta del comentario seleccionado en su lugar, o puede pulsar la tecla Supr de su teclado o el atajo de teclado Alt+d para eliminar el comentario seleccionado.
 
-1. En el menú "Anotaciones" seleccione el elemento "exportador de notas"...
-2. Seleccione el rango de exportación. Esto indicará a Bookworm que desea exportar las notas ya sea de todo el libro o exportar las notas de la sección actual. 
-3. Seleccione el formato de salida. Esto determinará el formato del archivo conseguido tras la exportación. Exportando a texto plano le entregará un archivo de texto simple pero formateado, exportando a HTML obtendrá una página web y seleccionando markdown recibirá un documento markdown que es un formato de texto base estructurado popular entre usuarios informáticos expertos.
-4. Si necesita que Bookworm abra el archivo que contiene las notas exportadas, puede marcar la casilla "abrir archivo tras la exportación".
-5. Haga clic en Exportar. Se le pedirá que seleccione un nombre para el archivo exportado y una ubicación hacia la que se guardará. Haciendo clic en "guardar" se almacenará el archivo y se abrirá si le ha indicado a Bookworm tal acción.
+
+#### Exportar comentarios
+
+Bookworm le permite exportar sus comentarios a un archivo de texto plano o a un documento HTML, que puede abrirse en un navegador web. Opcionalmente, Bookworm le permite exportar sus comentarios a Markdown, que es un formato de texto para escribir documentos estructurados muy popular entre los usuarios avanzados de ordenadores.
+
+Para exportar comentarios, siga estos pasos:
+
+1. En el menú de anotaciones, navegue hasta Comentarios guardados;
+2. Busque «Exportar» y pulse Intro. También puede utilizar la combinación de teclas Alt+x para abrir el menú de exportación;
+
+A continuación, tiene las siguientes opciones, puede desmarcar o dejar marcada cualquier opción que desee:
+
+* Incluir título del libro - esta opción le permite incluir el título del libro en el archivo de salida final cuando exporta comentarios;
+* Incluir título de sección - opción que se utiliza para incluir el título de la sección en la que se deja el comentario;
+* Incluir número de página - esta opción se utiliza para incluir los números de las páginas en las que se hizo el comentario;
+* Incluir etiquetas - esta opción se utiliza para incluir o no las etiquetas del comentario que se hicieron durante la anotación.
+
+Después de especificar la opción correcta según sus necesidades, debe seleccionar el formato de salida del archivo, de los que actualmente hay tres: formato de texto sin formato, Html y Markdown.
+Una vez seleccionado el formato deseado, aparece un área de texto de sólo lectura denominada «Archivo de salida» y vacía por defecto. Debe hacer clic en el botón Examinar o, alternativamente, utilizar alt+b para abrir una ventana del explorador y especificar el nombre de archivo y la carpeta donde se guardará el archivo de salida.
+Al especificar un nombre de archivo y una carpeta de archivo, hay una casilla de verificación «Abrir archivo después de exportar» que permite a Bookworm abrir automáticamente el archivo de salida después de guardarlo. Desactive esta casilla si no desea abrir automáticamente el archivo guardado y haga clic en Aceptar. El archivo se guardará en la carpeta especificada y podrá abrirlo con Bookworm o con cualquier otro editor de texto, como «Bloc de notas».
 
 
 ### Lectura en voz alta
 
-Bookworm soporta leer el contenido del libro abierto utilizando una voz TTS. Solamente presione F5 para iniciar la voz, , F6 para pausar o reanudar y F7 para detenerla por completo.
+Bookworm permite leer en voz alta el contenido del documento abierto utilizando una voz de texto a voz instalada. Basta con pulsar F5 para iniciar la reproducción, F6 para pausarla o reanudarla y F7 para detenerla por completo.
 
-Usted puede configurar la voz de dos maneras:
-1. Usando un perfil de voz: un perfil de voz contiene sus ajustes personalizados del habla, que puede ser activado o desactivado en cualquier momento. Puede acceder a los perfiles de voz desde el menú voz o presionando Ctrl + Shift + V. Nótese que Bookworm ofrece algunos perfiles preestablecidos.
-2. Mediante los ajustes globales TTS: estos ajustes se usarán de forma predeterminada si no hay un perfil de voz activo. Usted puede configurar los ajustes globales de voz desde las preferencias de la aplicación.
+Puede configurar el habla de dos maneras:
+1. Utilizando un perfil de voz: Un perfil de voz contiene sus configuraciones de habla personalizadas, puede activar/desactivar el perfil de voz en cualquier momento. Puede acceder a los perfiles de voz desde el menú de voz o pulsando Ctrl + Mayús + V. Tenga en cuenta que Bookworm viene con algunos perfiles de voz incorporados ejemplares.
+2. Los ajustes globales de voz: estos ajustes se utilizarán por defecto cuando no haya ningún perfil de voz activo. Puede configurar los ajustes globales de voz desde las preferencias de la aplicación. 
 
-Durante la lectura, usted puede moverse hacia adelante y atrás por párrafo presionando Alt más las flechas izquierda y derecha.
+Durante la lectura en voz alta, puedes saltar hacia atrás o hacia delante por párrafos pulsando Alt más las teclas de flecha izquierda y derecha.
 
 
-### Configurando el estilo de lectura
+### Configuración del estilo de lectura
 
-Además de los ajustes de voz, Bookworm le dal a posibilidad de modificar su comportamiento al leer mediante estas configuraciones. Todos los ajustes siguientes se encuentran en la página "Lectura" desde las preferencias de la aplicación.
+Además de los ajustes de voz, Bookworm te da la posibilidad de ajustar su comportamiento de lectura a través de estos ajustes. Todos los ajustes siguientes se pueden encontrar en la página de lectura de las preferencias de la aplicación.
 
-* Al reproducir: Esta opción controla lo que sucede al indicarle a Bookworm que reproduzca el libro actual. Puede elegir entre  "Leer todo el libro", "Leer la sección actual" o leer sólo "La página actual". De forma predeterminada, Bookworm lee todo el libro continuamente, a menos que se le ordene detenerse cuando se alcance el final de la página o de la sección.
-* Empezar a leer desde: Esta opción controla la posición desde la que se inicia la lectura en voz alta. Usted puede elegir entre empezar a leer desde la posición del cursor o de la página actual.
-* Durante la lectura: el siguiente conjunto de opciones controla cómo se comporta Bookworm mientras se lee en voz alta. Puede activar o desactivar cualquiera de las opciones siguientes marcando o desmarcando las casillas correspondientes:
+* Al pulsar Reproducir: Esta configuración determina lo que sucede cuando le dices a Bookworm que «Reproduzca» el documento actual. Puede seleccionar «Leer todo el documento», «Leer la sección actual» o leer sólo la «página actual». Por defecto, Bookworm lee continuamente todo el documento a menos que le digas que se detenga cuando llegue al final de la página o al final de la sección actual.
+* Empezar a leer desde: esta opción determina la posición desde la que empezar a leer en voz alta. Puedes empezar a leer desde la «Posición del cursor» o desde el «Inicio de la página actual».
+* Durante la lectura en voz alta: este conjunto de opciones controla cómo se comporta Bookworm durante la lectura en voz alta. Puede activar/desactivar cualquiera de las siguientes opciones marcando/desmarcando su respectiva casilla:
 
-* Resaltar texto leído: Si esta opción está activada, el texto que se lee será visualmente resaltado
-* Seleccionar texto leído: si esta opción está activada, el texto leído será seleccionado. Por ejemplo, esto le permite presionar CTRL+C para copiar el párrafo leído actualmente.
-* Reproducir sonido para fin de sección: Si esta opción está activada, Bookworm reproduce un sonido cuando se alcance el final de sección.
+* Pronunciar el número de página: el texto a voz pronunciará cada página a medida que navegue hasta ella;
+* Anunciar el final de las secciones: cuando termine una sección, la voz le avisará;
+* Pedir que se cambie a una voz que hable el idioma del libro actual - esta opción determinará si Bookworm avisará o no de una voz incompatible, lo que ocurre por defecto cuando la voz del idioma de texto-a-voz seleccionado difiere del idioma del documento abierto;
+* Resaltar texto hablado: si esta opción está activada, el texto hablado en ese momento se resalta visualmente.
+* Seleccionar texto hablado: si esta opción está activada, se selecciona el texto hablado en ese momento. Esto le permite, por ejemplo, pulsar Ctrl + C para copiar el párrafo hablado en ese momento.
 
 
 ### Modo de lectura continua
 
-Además de las funciones incluidas de Texto a voz en Bookworm, puede aprovechar la función lectura continua de lector de pantalla (también conocida como "Verbalizar todo"). Bookworm ofrece soporte para esta característica mediante el "modo de lectura continua". De forma predeterminada este modo está activo y puede desactivarse en la pestaña Lectura en las preferencias de la aplicación. Mientras que el modo de lectura continua esté en uso, se irán pasando las páginas en cuanto el lector de pantalla progrese en el libro.
+Además de las funciones incorporadas de texto a voz de Bookworm, puede aprovechar la funcionalidad de lectura continua de su lector de pantalla (también conocida como «decirlo todo»). Bookworm proporciona soporte para esta funcionalidad a través de su «modo de lectura continua». Este modo está activo por defecto, y puedes desactivarlo desde la página de lectura de las preferencias de la aplicación. Mientras el modo de lectura continua está activo, las páginas se pasan automáticamente a medida que el lector de pantalla avanza por el documento.
 
-Nótese que debido a la forma en que este modo se ha implementado, deben tenerse en cuenta las siguientes limitaciones:
+Tenga en cuenta que, debido a la forma en que esta función está implementada actualmente, cabe esperar las siguientes limitaciones:
 
-* La lectura continua se interrumpirá si se llega a una página en blanco. Si este es el caso, simplemente navegue a una página que no esté en blanco y reactive la lectura continua del lector de pantalla desde allí.
-* Si se mueve el cursor al último carácter en la página, se cambiará de inmediato a la página siguiente.
-
-
-
-### Ver una versión renderizada de la página actual
-
-Bookworm le permite ver una versión renderizada completa del libro. Mientras el libro esté abierto, puede presionar Ctrl + R o seleccionar la opción "Renderizar página" en el menú Herramientas. Le llamamos "vista renderizada" en contraste con la vista textual predeterminada.
-
-Cuando esté en la vista renderizada, puede utilizar los comandos estándar para acercar o alejar la página:
-
-* Ctrl + = Aumentar el zoom
-* Ctrl + - Disminuir el zoom
-* Ctrl + 0 Restablecer el nivel de zoom
-
-Cabe mencionar que también puede usar los comandos de navegación del libro citados anteriormente  para desplazarse por la vista renderizada. También puede presionar Escape para cerrar esta vista y regresar a la ventana textual por defecto.
+* La lectura continua se interrumpirá si se llega a una página vacía. Si llega a una página vacía, simplemente navegue a una página que no esté vacía y reactive la funcionalidad de lectura continua de su lector de pantalla desde allí.
+* Si mueve el cursor hasta el último carácter de la página, pasará inmediatamente a la página siguiente.
 
 
-Navegando a una página específica
+### Ver una versión completamente renderizada de la página actual
 
-Para navegar a una página de su elección en el libro actualmente abierto, Presione Ctrl + G o seleccione la opción "Ir a..." desde el menú herramientas para mostrar este diálogo. Aquí puede escribir el número de cualquier página hacia donde quiera moverse y Bookworm lellevará a ella. Nótese que este diálogo le indicará el número total de páginas disponibles en el libro.
+Bookworm le permite ver una versión completamente renderizada del documento. Mientras el documento está abierto, puede pulsar Ctrl + R o seleccionar la opción «Renderizar página» del menú del documento. Llamamos a esta vista «Vista de renderizado», en contraposición a la vista textual por defecto.
+
+Cuando esté en la vista de renderizado, puede utilizar los comandos de zoom habituales para acercar o alejar la página:
+
+* Ctrl + = acercar 
+* Ctrl + - alejar
+* Ctrl + 0 restablecer el nivel de zoom
+
+Tenga en cuenta que también puede utilizar los comandos de navegación del documento, mencionados anteriormente, para navegar por la vista de renderizado. También puedes pulsar la tecla escape para descartar esta vista y volver a la vista textual por defecto.
+
+
+### Navegar a una página específica
+
+Para navegar a una página específica en el documento actualmente abierto, pulse Ctrl + G, o seleccione la opción «Ir a la página...» del menú de búsqueda para mostrar el diálogo «Ir a la página». En este diálogo puede escribir el número de cualquier página a la que desee navegar, y Bookworm le llevará a ella. Tenga en cuenta que este diálogo le indicará el número total de páginas encontradas en el documento actual.
 
  
-### Buscando en el libro
+### Búsqueda en el documento
 
-Para buscar un término específico o una porción de texto en el libro actualmente abierto, puede presionar Ctrl + F para mostrar el diálogo "buscar en el libro". Este diálogo le permite escribir el texto que desee buscar así como configurar el proceso de búsqueda. Las siguientes opciones están disponibles:
+Para encontrar un término específico, o un fragmento de texto en el documento actualmente abierto, puede pulsar Ctrl + F para abrir el «Diálogo de búsqueda en el documento». Este diálogo le permite escribir el texto que desea buscar y configurar el proceso de búsqueda. Dispone de las siguientes opciones:
 
-* Sensible a las mayúsculas: La búsqueda tendrá en cuenta las mayúsculas o minúsculas en el término de búsqueda.
-* Buscar palabras completas: el término de búsqueda debe encontrarse como una palabra entera, p. ej. no como parte de otra existente.
-* Rango de búsqueda: Esto le permite limitar la búsqueda a ciertas páginas o a una sección específica.
+* Sensible a mayúsculas y minúsculas: La búsqueda tendrá en cuenta las mayúsculas y minúsculas del término buscado.
+* Buscar sólo palabra completa: El término buscado debe encontrarse como palabra completa, es decir, no como parte de otra palabra.
+* Rango de búsqueda: Permite limitar la búsqueda a determinadas páginas o a una sección específica.
 
-Tras hacer clic en Aceptar en el "diálogo buscar", aparecerá un segundo diálogo con los resultados de la búsqueda. Haciendo clic en cualquier elemento en la lista de resultados lo llevará a la posición correspondiente con el término de búsqueda resaltado para usted.
+Tras pulsar el botón OK en el «Diálogo del documento de búsqueda», se mostrará otro diálogo con los resultados de la búsqueda. Si hace clic en cualquier elemento de la lista de resultados de la búsqueda, irá inmediatamente a la posición de ese resultado con el término de búsqueda resaltado para usted.
 
-Nótese que si ya ha cerrado la ventana con la lista de resultados, puede presionar F3 y Shift+F3 para moverse a la aparición anterior y siguiente de la última búsqueda, respectivamente.
-
-
-## Gestionando asociaciones de archivo
-
-el botón "Administrar asociaciones" que se encuentra en la página general en las preferencias de la aplicación le ayuda a administrar qué tipos de archivo están asociados con Bookworm. Asociar archivos con Bookworm significa que cuando abra un archivo en el explorador de Windows, ese archivo será abierto por Bookworm por defecto. Nótese que este diálogo siempre se muestra al usuario tras la primera ejecución.
-
-Una vez que inicie el gestor de asociaciones de archivo, contará con las siguientes opciones:
-
-* Asociar todo: esto modifica los ajustes de tal forma que si Bookworm soporta un archivo, Windows lo utilizará para abrir el archivo.
-* Desasociar todos los tipos de archivos soportados: esto eliminará las asociaciones de archivo anteriormente guardadas.
-* Botones individuales para cada tipo de archivo soportado: haciendo clic en cualquier botón de ellos, se asociará su respectivo tipo de archivo con Bookworm.
+Tenga en cuenta que si ha cerrado la ventana de resultados de búsqueda, puede pulsar F3 y Mayúsculas + F3 para desplazarse a la aparición siguiente y anterior de la última búsqueda, respectivamente.
 
 
-Actualizando Bookworm
+## Gestionar Asociaciones de Archivos
 
-De forma predeterminada, Bookworm comprueba si hay nuevas versiones al iniciarse. Esto asegura que usted consiga lo último y lo mejor de Bookworm lo más pronto posible. Usted puede desactivar este comportamiento desde las preferencias de la aplicación. También puede hacer esto manualmente seleccionando el elemento "Comprovar actualizaciones" en el menú "Ayuda".
+El botón administrar asociaciones de archivos», que se encuentra en la página general de las preferencias de la aplicación, le ayuda a gestionar qué tipos de archivos están asociados con Bookworm. Asociar archivos con Bookworm significa que cuando pulses sobre un archivo en el explorador de Windows, ese archivo se abrirá en Bookworm por defecto. Tenga en cuenta que este cuadro de diálogo siempre se muestra al usuario la primera vez que inicia el programa y sólo está disponible cuando se utiliza el instalador, en la versión portable esta opción no es necesaria, respectivamente, en la versión portable, la capacidad de asociar archivos está desactivada y se requieren algunos trucos si aún desea que Bookworm abra cualquier documento soportado por defecto.
 
-De cualquier forma, si se encuentra una nueva versión, Bookworm le preguntará si desea instalarla. Si selecciona "Sí", la aplicación proseguirá y descargará el paquete de actualización, mostrando un diálogo indicando el proceso de descarga. Después de que haya finalizado, Bookworm le alertará con un mensaje indicando que la aplicación debe reiniciarse para actualizarse.
+Una vez que lances el administrador de asociaciones de archivos, tendrás las siguientes opciones:
+
+* Asociar todos: cambia la configuración de modo que si un archivo es compatible con Bookworm, Windows lo abrirá con Bookworm. 
+* Desasociar todos los tipos de archivos compatibles: esto eliminará las asociaciones de archivos registradas previamente.
+* Botones individuales para cada tipo de archivo soportado: al hacer clic en cualquiera de ellos se asociará su respectivo tipo de archivo con Bookworm.
 
 
-## Reportando problemas / dificultades
+## Actualizar Bookworm
 
-Como desarrolladores ciegos, nuestra responsabilidad es desarrollar aplicaciones que brinden independencia para nosotros y nuestros compañeros ciegos por todo el mundo. Por lo tanto, si ha encontrado útil Bookworm de alguna forma, por favor ayúdenos en mejorar Bookworm para usted y los demás. En esta etapa inicial, queremos que nos haga saber sobre cualquier error que encuentre al usar Bookworm. Para ello, abra un nuevo asunto con detalles del error en [el Rastreador de problemas](https://github.com/mush42/bookworm/issues/). Muchas gracias por su ayuda.
+Por defecto, Bookworm busca nuevas versiones al iniciarse. Esto asegura que obtengas la última y mejor versión de Bookworm lo antes posible. Puedes desactivar este comportamiento por defecto desde las preferencias de la aplicación.   También puedes buscar actualizaciones manualmente haciendo clic en la opción «comprobar actualizaciones» del menú «Ayuda».
 
-Antes de  enviar un nuevo problema, asegúrese de haber ejecutado Bookworm en modo de depuración. Para activarlo, vaya al menú "Ayuda" y haga clic en iniciar en modo de depuración activado e intente reproducir dicho problema. En la mayoría de los casos, cuando se produzca el error de nuevo con este modo activo, se mostrará un diálogo con los detalles del error. Así podrá copiar esta información e incluirla con el reporte del fallo.
+En cualquier caso, cuando se encuentre una nueva versión, Bookworm le preguntará si desea instalarla. Si haces clic en «Sí», la aplicación descargará el paquete de actualización y mostrará un cuadro de diálogo indicando el progreso de la descarga. Una vez descargada la actualización, Bookworm te avisará con un mensaje, indicándote que reiniciará la aplicación para actualizar. Haz clic en «Aceptar» para completar el proceso de actualización.
 
-Note que algunos fallos pueden ser difíciles de reproducir ya que desaparecen al reiniciar el programa. En este caso, es válido reportar el error con el modo de depuración activado. Sólo asegúrese de incluir cuanta más información le sea posible particularmente de su sistema y el escenario de uso.
+
+## Notificación de problemas
+
+Como desarrolladores ciegos, nuestra responsabilidad es desarrollar aplicaciones que nos proporcionen independencia a nosotros y a nuestros amigos ciegos de todo el mundo. Así que, si has encontrado Bookworm útil de alguna manera, por favor ayúdanos a hacer Bookworm mejor para ti y para los demás. En esta fase inicial, queremos que nos comentes cualquier error que encuentres durante el uso de Bookworm. Para ello, abre una nueva incidencia con los detalles del error en [el gestor de incidencias](https://github.com/blindpandas/bookworm/issues/). Agradecemos enormemente tu ayuda.
+
+Antes de enviar una nueva incidencia, asegúrate de que has ejecutado Bookworm en modo depuración. Para activar el modo de depuración, vaya al menú «Ayuda» y haga clic en «Reiniciar con el modo de depuración habilitado» e intente reproducir el problema con el modo de depuración activado. En la mayoría de los casos, cuando el error vuelva a producirse con el modo de depuración activado, se mostrará un cuadro de diálogo con los detalles de dicho error. A continuación, puede copiar esta información e incluirla en su informe del problema.
+
+Tenga en cuenta que algunos problemas pueden ser difíciles de reproducir, desaparecen cuando reinicia el programa. En este caso, está bien informar del problema sin la información detallada del modo de depuración. Sólo asegúrese de incluir tanta información como sea posible acerca de las particularidades de su sistema y escenario de uso.
 
 
 ## Noticias y actualizaciones
 
-Para mantenerse al tanto con las últimas noticias de Bookworm, puede visitar el sitio web de Bookworm (en inglés): [mush42.github.io/bookworm](https://mush42.github.io/bookworm/). También puede seguir al desarrollador principal, Musharraf Omer, como [@mush42](https://twitter.com/mush42/) en Twitter.
+Para mantenerte al día con las últimas noticias sobre Bookworm, puedes visitar el sitio web de Bookworm en: [github.com/blindpandas/bookworm](https://github.com/blindpandas/bookworm/). También puedes seguir al desarrollador principal, Musharraf Omer, en [@mush42](https://twitter.com/mush42/) en Twitter.
 
 
 ## Licencia
 
-**Bookworm** es copyright (c) 2019 Musharraf Omer y ayudantes de Bookworm. Bajo la [Licencia MIT License](https://github.com/mush42/bookworm/blob/master/LICENSE).
+**Bookworm** es copyright (c) 2019-2023 Musharraf Omer y Bookworm Contributors. Está licenciado bajo la [Licencia MIT](https://github.com/blindpandas/bookworm/blob/master/LICENSE).


### PR DESCRIPTION
## Link to issue number:
fix #281 

### Summary of the issue:
Bookworm does not contain Spanish translations
### Description of how this pull request fixes the issue:
Added Spanish translation for Bookworm, including documentation and interface translations.
### Testing performed:
Manual testing
### Known issues with pull request:

