### PR TITLE
fix(epub, word): Update the documents cache whenever the file is modified

### DIFF
--- a/bookworm/document/cache_utils.py
+++ b/bookworm/document/cache_utils.py
@@ -1,0 +1,23 @@
+"""Caching utilities"""
+from pathlib import Path
+
+from diskcache import Cache
+
+
+def is_document_modified(key: str, path: Path, cache: Cache) -> bool:
+    """
+    Checks whether a particular document was modified
+    We can currently afford to naively just stat() the file_path in order to determine it
+    """
+    mtime = cache.get(f"{key}_meta")
+    if not mtime:
+        # No information for the book was found, so return True just to be safe
+        # TODO: Is this acceptable?
+        return True
+    stat_mtime = path.stat().st_mtime
+    return mtime != stat_mtime
+
+def set_document_modified_time(key: str, path: Path, cache: Cache) -> bool:
+    key = f"{key}_meta"
+    cache.set(key, path.stat().st_mtime)
+    

--- a/tests/test_epub.py
+++ b/tests/test_epub.py
@@ -1,14 +1,57 @@
+from pathlib import Path
+
+from ebooklib import epub
 import pytest
 
 from bookworm.document.uri import DocumentUri
 from bookworm.document.formats.epub import EpubDocument
 
+def temp_book(title: str = 'Sample book') -> epub.EpubBook:
+    book = epub.EpubBook()
+    book.set_title("test book")
+    book.set_language('en')
+    c1 = epub.EpubHtml(title="Intro", file_name="chap_01.xhtml", lang="en")
+    c1.content = (
+        "<h1>This is a test</h1>"
+    )
+    book.add_item(c1)
+    book.toc = (
+        epub.Link("chap_01.xhtml", "Introduction", "intro"),
+        (epub.Section("Simple book"), (c1,)),
+    )
+
+    book.add_item(epub.EpubNcx())
+    book.add_item(epub.EpubNav())
+    book.spine = ["nav", c1]
+    return book
+
 
 def test_chapter_order_is_unchanged_with_roman_numbers(asset):
-    epub = EpubDocument(DocumentUri.from_filename(asset('roman.epub')))
-    epub.read()
-    spine = [x[0] for x in epub.epub.spine]
-    items = [x.file_name.split('/')[-1] for x in epub.epub_html_items]
-    print(items)
-    print(spine)
+    doc = EpubDocument(DocumentUri.from_filename(asset('roman.epub')))
+    doc.read()
+    spine = [x[0] for x in doc.epub.spine]
+    items = [x.file_name.split('/')[-1] for x in doc.epub_html_items]
     assert spine == items
+
+def test_modified_epub_modifies_cache(asset):
+    book = temp_book()
+    epub.write_epub(asset("test.epub"), book, {})
+    doc = EpubDocument(DocumentUri.from_filename(asset('test.epub')))
+    doc.read()
+    content = doc.html_content
+
+    # Let's now add a second chapter, and see whether the document read modifies its cache
+    c2 = epub.EpubHtml(title="Second chapter", file_name="chap_02.xhtml", lang="en")
+    c2.content = (
+        "<h1>This is another test</h1>"
+    )
+    book.add_item(c2)
+    book.spine.append(c2)
+    epub.write_epub(asset("test.epub"), book, {})
+
+    # read the book once more, and verify that the content is different
+    doc = EpubDocument(DocumentUri.from_filename(asset('test.epub')))
+    doc.read()
+    new_content = doc.html_content
+    Path(asset("test.epub")).unlink()
+    assert content != new_content


### PR DESCRIPTION
## Link to issue number:
fixes #288 
### Summary of the issue:
Certain document formats, as of now only word and epub, cache their HTML representation to be loaded in subsequent reads. However, the cache was not properly updated whenever the document itself would change
### Description of how this pull request fixes the issue:
We now also keep track of the document's modified time, and update the cache accordingly if the document appears to be modified.
The check we do is probably very naive, but the use case is simplistic enough that it shouldn't matter.
### Testing performed:
Unit tests were added
### Known issues with pull request:
None that I could see
