### PR TITLE
fix(gui): Swap zoom button labels for clarity in BookViewerToolbar

### DIFF
--- a/bookworm/gui/book_viewer/__init__.py
+++ b/bookworm/gui/book_viewer/__init__.py
@@ -414,9 +414,9 @@ class BookViewerWindow(wx.Frame, MenubarProvider, StateProvider):
             (20, "reading_mode", _("Mode"), BookRelatedMenuIds.changeReadingMode),
             (32, "", "", None),
             # Translators: the label of a button in the application toolbar
-            (60, "zoom_out", _("Big"), wx.ID_PREVIEW_ZOOM_OUT),
+            (60, "zoom_out", _("Small"), wx.ID_PREVIEW_ZOOM_OUT),
             # Translators: the label of a button in the application toolbar
-            (70, "zoom_in", _("Small"), wx.ID_PREVIEW_ZOOM_IN),
+            (70, "zoom_in", _("Big"), wx.ID_PREVIEW_ZOOM_IN),
             (71, "", "", None),
         ]
         tool_info.extend(wx.GetApp().service_handler.get_toolbar_items())


### PR DESCRIPTION
## Link to issue number:
N/A

### Summary of the issue:
Toolbar zoom in and zoom out buttons were mislabeled, causing functionality confusion.

### Description of how this pull request fixes the issue:
Corrected the labels for zoom in and zoom out buttons to match their functionality.

### Testing performed:
Manually tested the toolbar buttons to ensure correct zoom functionality.

### Known issues with pull request:
None
