### PR TITLE
feat(ui): Add text wrapping option

### DIFF
--- a/bookworm/config/spec.py
+++ b/bookworm/config/spec.py
@@ -29,6 +29,7 @@ config_spec = StringIO(
     font_point_size = integer(default=12)
     use_bold_font = boolean(default=False)
     text_view_margins = integer(default=10, min=0, max=100)
+    text_wrap = boolean(default=False)
 [advanced]
 """
 )

--- a/bookworm/gui/settings.py
+++ b/bookworm/gui/settings.py
@@ -415,6 +415,13 @@ class AppearancePanel(SettingsPanel):
             _("Apply text styling (when available)"),
             name="appearance.apply_text_styles",
         )
+        self.textWrapCheckBox = wx.CheckBox(
+            UIBox,
+            -1,
+            # Translators: the label of a checkbox
+            _("Enable text wrapping (requires restart)"),
+            name="appearance.text_wrap",
+        )
         wx.StaticText(UIBox, -1, _("Text view margins percentage"))
         EnhancedSpinCtrl(UIBox, -1, min=0, max=100, name="appearance.text_view_margins")
         # Translators: the title of a group of controls in the
@@ -468,6 +475,21 @@ class AppearancePanel(SettingsPanel):
                 self.fontChoice.SetSelection(0)
         elif strategy is ReconciliationStrategies.save:
             self.config["font_facename"] = self.fontChoice.GetStringSelection()
+            if self.textWrapCheckBox.GetValue() != self.config["text_wrap"]:
+                msg = wx.MessageBox(
+                    # Translators: the content of a message asking the user to restart
+                    _(
+                        "You have changed the text wrapping setting.\n"
+                        "For this setting to fully take effect, you need to restart the application.\n"
+                        "Would you like to restart the application right now?"
+                    ),
+                    # Translators: the title of a message telling the user
+                    # that the text wrapping setting has been changed
+                    _("Text Wrapping Changed"),
+                    style=wx.YES_NO | wx.ICON_WARNING,
+                )
+                if msg == wx.YES:
+                    restart_application()
         super().reconcile(strategy=strategy)
         if strategy is ReconciliationStrategies.save:
             wx.GetApp().mainFrame.set_content_view_font()

--- a/bookworm/gui/text_ctrl_mixin.py
+++ b/bookworm/gui/text_ctrl_mixin.py
@@ -6,6 +6,7 @@ import wx.lib.newevent
 import bookworm.typehints as t
 from bookworm.logger import logger
 from bookworm.structured_text import SemanticElementType
+from bookworm import config
 
 log = logger.getChild(__name__)
 
@@ -61,10 +62,13 @@ class ContentViewCtrlMixin(wx.TextCtrl):
     def __init__(self, parent, *args, label="", **kwargs):
         self.panel = self.ContainingPanel(self, parent, size=parent.GetSize())
         self.controlLabel = wx.StaticText(self.panel, -1, label)
+        style = self.TEXTCTRL_STYLE
+        if not config.conf["appearance"]["text_wrap"]:
+            style |= wx.TE_DONTWRAP
         super().__init__(
             self.panel,
             *args,
-            style=self.TEXTCTRL_STYLE,
+            style=style,
             **kwargs,
         )
         sizer = wx.BoxSizer(wx.HORIZONTAL)


### PR DESCRIPTION
## Link to issue number:
N/A

### Summary of the issue:
Need to add a configurable text wrapping option in the appearance settings panel.

### Description of how this pull request fixes the issue:
- Added `text_wrap` boolean config option in spec.py
- Added checkbox in AppearancePanel for text wrapping control
- Implemented restart prompt when text wrap setting changes
- Updated text control to use text wrapping configuration

### Testing performed:
- Verified config saving/loading
- Tested settings UI interaction
- Confirmed restart prompt works
- Validated text wrapping behavior after restart

### Known issues with pull request:
- Requires application restart to take effect
  - The wx.TE_DONTWRAP style flag must be set when creating the TextCtrl
  - This style cannot be changed after the control is created