### PR TITLE
feat: Allow book metadata to be imported from QRD files

### DIFF
--- a/bookworm/gui/book_viewer/menu_constants.py
+++ b/bookworm/gui/book_viewer/menu_constants.py
@@ -45,6 +45,9 @@ class ViewerMenuIds(enum.IntEnum):
     about = next(ID_GEN)
     clear_documents_cache = next(ID_GEN)
 
+class ImportMenuIds(enum.IntEnum):
+    """Ids for the import submenu"""
+    qread = next(ID_GEN)
 
 FOCUS_TABLE_OF_CONTENTS = next(ID_GEN)
 

--- a/bookworm/qread/__init__.py
+++ b/bookworm/qread/__init__.py
@@ -1,0 +1,37 @@
+"""QRead interoperability"""
+import sqlite3
+from typing import Optional
+
+from pydantic import BaseModel, ValidationError
+
+from bookworm.logger import logger
+
+log = logger.getChild(__name__)
+
+class BookInfo(BaseModel):
+    """Saved book information
+    QRead stores book metadata inside a .qrd file, which is an unencrypted sqlite database
+    The table we are interested from is named shelf, and it contains information related to book position, among other things
+    """
+    # Current position of the book
+    current_position: int
+    # File location of the book
+    original_path: str
+
+
+def get_book_info(qrd_path: str) -> Optional[BookInfo]:
+    """Connects to the .qrd sqlite database and retrieves the book information we require, if any"""
+    log.debug(f"Connecting to {qrd_path}")
+    with sqlite3.connect(qrd_path) as conn:
+        cur = conn.cursor()
+        # the shelf table is made up by two columns, key and value
+        cur.execute('SELECT value FROM shelf WHERE key="book.json"')
+        try:
+            value = cur.fetchone()[0]
+            info = BookInfo.model_validate_json(value)
+            return info
+        except ValidationError:
+            log.error("Failed to obtain book information from QRD file", exc_info=True)
+            return None
+        finally:
+            cur.close()


### PR DESCRIPTION
This PR adds a menu option that allows users to import book metadata from QRD files.
fixes #303

A concern I raised in the issue itself was related to any possible license violation that may occur by us implementing this change, but after further investigation, it would appear that this may not be a problem for the following reasons:
* We're not reverse engineering the program, but only analyzing a file used by it
* The file itself is a sqlite3 database, which is open source. Furthermore, the QRD file itself does not appear to have any DRM or encryption what so ever.

If there are any things I may have missed feel free to point them out.

cc: @cary-rowen 