### PR TITLE
fix: Fixed .docx documents not opening

### DIFF
--- a/bookworm/document/formats/word.py
+++ b/bookworm/document/formats/word.py
@@ -86,7 +86,7 @@ class WordDocument(BaseHtmlDocument):
 
     def _get_html_content_from_docx(self, data_buf, is_encrypted_document):
         data_buf.seek(0)
-        doc_path = self.get_file_system_path
+        doc_path = self.get_file_system_path()
         cache = Cache(
             self._get_cache_directory(), eviction_policy="least-frequently-used"
         )


### PR DESCRIPTION
Basically this was a minor typo, which made the path have as value the function object rather than the actual path
fixes #314 