### PR TITLE
revert: Partially revert changes from #318 in link navigation

### DIFF
--- a/bookworm/reader.py
+++ b/bookworm/reader.py
@@ -420,7 +420,7 @@ class EBookReader:
             start, end = target_info.position
             start += 1
             self.perform_wormhole_navigation(
-                page=target_info.page, start=start, end=end, last_position=link_range
+                page=target_info.page, start=start, end=None, last_position=link_range
             )
 
     def get_view_title(self, include_author=False):


### PR DESCRIPTION
## Link to issue number:
Follow-up to #318
### Summary of the issue:
An unintended change in #318 caused some issues: for example, the content of the line where the cursor was located was not reported after following a jump link.

### Description of how this pull request fixes the issue:
Revert the use of `end=end` in `perform_wormhole_navigation` call within `navigate_to_link_by_range`, restoring `end=None`.
This fixes a `start > end` error encountered after navigating internal links. The error was caused by the combination of the `start += 1` adjustment (introduced in #318 to fix cursor positioning) and passing an explicit `end` value derived from `target_info.position`.
Restoring `end=None` resolves the range error by instructing the view to only set the cursor position (`start`) without selecting a potentially invalid range, while still respecting the necessary cursor adjustment from #318.
### Testing performed:
Manual testing
### Known issues with pull request:

unknown